### PR TITLE
adjust --context flag to --kubecontext to maintain consistent naming …

### DIFF
--- a/cmd/reliably/discover.go
+++ b/cmd/reliably/discover.go
@@ -238,7 +238,7 @@ manifests file from the current working directory.`,
 	)
 
 	cmd.Flags().StringVarP(
-		&opts.KubernetesContext, "context", "c", os.Getenv("KUBECONTEXT"), "Specifies the Kubernetes context to evaluate when scanning live cluster",
+		&opts.KubernetesContext, "kubecontext", "c", os.Getenv("KUBECONTEXT"), "Specifies the Kubernetes context to evaluate when scanning live cluster",
 	)
 
 	configPath, _ := k8s.FindKubeConfigPath()


### PR DESCRIPTION
This pull request resolves #68