### PR TITLE
fix: printing 1:1 as line and column reference when we don't know the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 - policy retrieval logic has been changed to incorporate the API Version into the path to the remote policy. Locally cached policy also includes the API Version.
+- changed suggestion printing to exclude line numbers when they are ':1:1' - this indicates that we couldn't extract a line number and so are using defaults.
 
 ## [0.5.0] - 2021-03-03
 

--- a/core/output/formatter.go
+++ b/core/output/formatter.go
@@ -363,10 +363,7 @@ func plainTextFuncMap(enableColor bool) plainTemplate.FuncMap {
 			"printLevel": func(l core.Level) string {
 				return l.ColoredString()
 			},
-			"printLiveFileLocation": func(s string, kind string) string {
-				r := kind + ":"
-				return strings.Replace(s, r, "", 1)
-			},
+			"printLiveFileLocation": printLiveFileLocation,
 			"levelSymbol": func(l core.Level) string {
 				return l.ColoredSquare()
 			},
@@ -400,10 +397,7 @@ func plainTextFuncMap(enableColor bool) plainTemplate.FuncMap {
 		"printLevel": func(l core.Level) string {
 			return l.String()
 		},
-		"printLiveFileLocation": func(s string, kind string) string {
-			r := kind + ":"
-			return strings.Replace(s, r, "", 1)
-		},
+		"printLiveFileLocation": printLiveFileLocation,
 		"levelSymbol": func(l core.Level) string {
 			return l.String()[0:1]
 		},
@@ -457,4 +451,16 @@ func convertToCcReport(data *reportInfo) (*ccReport, error) {
 	}
 
 	return &issues, nil
+}
+
+func printLiveFileLocation(location string, kind string) string {
+	oldLocation := location
+
+	// Trim away the default location
+	if strings.HasSuffix(oldLocation, ":1:1") {
+		oldLocation = oldLocation[:len(oldLocation)-4]
+	}
+
+	r := kind + ":"
+	return strings.Replace(oldLocation, r, "", 1)
 }

--- a/core/output/sarif_format.go
+++ b/core/output/sarif_format.go
@@ -139,9 +139,6 @@ func buildSarifRule(suggestion *core.Suggestion) *sarifRule {
 func buildSarifLocation(suggestion *core.Suggestion, rootPath string) (*sarifLocation, error) {
 	var filePath string = suggestion.File
 
-	line := uint64(suggestion.Line)
-	col := uint64(suggestion.Col)
-
 	if rootPath != "" && strings.HasPrefix(suggestion.File, rootPath) {
 		filePath = strings.Replace(suggestion.File, rootPath+"/", "", 1)
 	}
@@ -151,12 +148,19 @@ func buildSarifLocation(suggestion *core.Suggestion, rootPath string) (*sarifLoc
 			ArtifactLocation: &sarifArtifactLocation{
 				URI: filePath,
 			},
-			Region: &sarifRegion{
-				StartLine:   line,
-				StartColumn: col,
-				//EndColumn:   col,
-			},
+			Region: &sarifRegion{},
 		},
+	}
+
+	if suggestion.Line > -1 && suggestion.Col > -1 {
+		line := uint64(suggestion.Line)
+		col := uint64(suggestion.Col)
+
+		location.PhysicalLocation.Region = &sarifRegion{
+			StartLine:   line,
+			StartColumn: col,
+			//EndColumn:   col,
+		}
 	}
 
 	return location, nil

--- a/core/suggestion.go
+++ b/core/suggestion.go
@@ -113,8 +113,8 @@ func NewSuggestion(result Result, live bool) *Suggestion {
 
 	if live {
 		filePath = result.Resource.Kind + ":" + result.Resource.Name
-		row = 0
-		col = 0
+		row = -1
+		col = -1
 	} else {
 		filePath = result.Resource.File.Filepath
 		row = result.Location.Row


### PR DESCRIPTION
… actual value

Added a simple check for a suffix of ':1:1' when printing the output. If we find that value then it is trimmed away.

fixes #120