### PR TITLE
Resolve missing data points in Reports

### DIFF
--- a/core/color/color.go
+++ b/core/color/color.go
@@ -1,6 +1,8 @@
 package color
 
 import (
+	"fmt"
+
 	"github.com/fatih/color"
 )
 
@@ -25,3 +27,45 @@ var (
 	BgMagenta = color.New(color.BgMagenta).SprintFunc()
 	BgRed     = color.New(color.BgRed).SprintFunc()
 )
+
+// Conditianal coloring - if the condition is true, the color is applied
+
+func IfTrueRed(condition bool, a ...interface{}) string {
+	if condition {
+		return Red(a...)
+	}
+
+	return fmt.Sprint(a...)
+}
+
+func IfTrueGreen(condition bool, a ...interface{}) string {
+	if condition {
+		return Green(a...)
+	}
+
+	return fmt.Sprint(a...)
+}
+
+func IfTrueMagenta(condition bool, a ...interface{}) string {
+	if condition {
+		return Magenta(a...)
+	}
+
+	return fmt.Sprint(a...)
+}
+
+func IfTrueCyan(condition bool, a ...interface{}) string {
+	if condition {
+		return Cyan(a...)
+	}
+
+	return fmt.Sprint(a...)
+}
+
+func IfTrueYellow(condition bool, a ...interface{}) string {
+	if condition {
+		return Yellow(a...)
+	}
+
+	return fmt.Sprint(a...)
+}

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -49,42 +49,50 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 		allLatency := []float64{}
 		allErrorPercentages := []float64{}
 
+		var latencyHasErrors = false
+		var errorPercentHasErrors = false
+
 		for _, resource := range s.Resources {
 			provider, err := getProviderForResource(resource.Provider)
 			if err != nil {
-				log.Errorf("an error occured while getting a provider for resource: %s => %s", resource.Provider, err)
-				continue
+				return nil, fmt.Errorf("an error occured while getting a provider for resource: %s => %s", resource.Provider, err)
 			}
 
 			to := time.Now()
-			from := to.Add(-oneDay)
+			from := to.Add(-oneHour)
 			r.ObservationWindow.To = to
 			r.ObservationWindow.From = from
 
 			if l, err := provider.Get99PercentLatencyMetricForResource(resource.ID, from, to); err == nil {
 				allLatency = append(allLatency, l)
 			} else {
-				return nil, fmt.Errorf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
+				log.Error(fmt.Errorf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err))
+				latencyHasErrors = true
 			}
 
 			if e, err := provider.GetErrorPercentageMetricForResource(resource.ID, from, to); err == nil {
 				allErrorPercentages = append(allErrorPercentages, e)
 			} else {
-				return nil, fmt.Errorf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
-			}
 
+				log.Error(fmt.Errorf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err))
+				errorPercentHasErrors = true
+			}
 		}
+
+		// define actual indicator data received and errors
+		actual := (&ServiceLevelIndicators{
+			ErrorPercent: average(allErrorPercentages),
+			LatencyMs:    int64(average(allLatency)),
+		}).setErrorState(latencyErr, latencyHasErrors).
+			setErrorState(errPercentErr, errorPercentHasErrors)
 
 		r.ServiceLevel = &ServiceLevel{
 			Target: &ServiceLevelIndicators{
 				ErrorPercent: s.Objective.ErrorBudgetPercent,
 				LatencyMs:    s.Objective.Latency.Milliseconds(),
 			},
-			Actual: &ServiceLevelIndicators{
-				ErrorPercent: average(allErrorPercentages),
-				LatencyMs:    int64(average(allLatency)),
-			},
-			Delta: &ServiceLevelIndicators{},
+			Actual: actual,
+			Delta:  &ServiceLevelIndicators{},
 		}
 
 		r.ServiceLevel.Delta.ErrorPercent = r.ServiceLevel.Actual.ErrorPercent - r.ServiceLevel.Target.ErrorPercent

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -59,7 +59,7 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 			}
 
 			to := time.Now()
-			from := to.Add(-oneHour)
+			from := to.Add(-oneDay)
 			r.ObservationWindow.To = to
 			r.ObservationWindow.From = from
 

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -66,7 +66,7 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 			if l, err := provider.Get99PercentLatencyMetricForResource(resource.ID, from, to); err == nil {
 				allLatency = append(allLatency, l)
 			} else {
-				log.Errorf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
+				log.Debugf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
 				latencyHasErrors = true
 			}
 
@@ -74,7 +74,7 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 				allErrorPercentages = append(allErrorPercentages, e)
 			} else {
 
-				log.Errorf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
+				log.Debugf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
 				errorPercentHasErrors = true
 			}
 		}

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/reliablyhq/cli/core/errors"
 	"github.com/reliablyhq/cli/core/manifest"
 	"github.com/reliablyhq/cli/core/metrics"
 	log "github.com/sirupsen/logrus"
@@ -42,7 +41,6 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 		}
 
 		r := Report{Name: s.Name}
-		allErrors := make([]error, 0)
 
 		r.APIVersion = apiVersion
 		r.Timestamp = timestampFn()
@@ -66,13 +64,13 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 			if l, err := provider.Get99PercentLatencyMetricForResource(resource.ID, from, to); err == nil {
 				allLatency = append(allLatency, l)
 			} else {
-				log.Errorf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
+				return nil, fmt.Errorf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
 			}
 
 			if e, err := provider.GetErrorPercentageMetricForResource(resource.ID, from, to); err == nil {
 				allErrorPercentages = append(allErrorPercentages, e)
 			} else {
-				log.Errorf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
+				return nil, fmt.Errorf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
 			}
 
 		}
@@ -94,10 +92,6 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 
 		if m.Dependencies != nil {
 			r.Dependencies = m.Dependencies
-		}
-
-		if len(allErrors) > 0 {
-			return reports, errors.NewCompoundError("multiple errors occured", allErrors)
 		}
 
 		reports = append(reports, &r)

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -66,7 +66,7 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 			if l, err := provider.Get99PercentLatencyMetricForResource(resource.ID, from, to); err == nil {
 				allLatency = append(allLatency, l)
 			} else {
-				log.Error(fmt.Errorf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err))
+				log.Errorf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
 				latencyHasErrors = true
 			}
 
@@ -74,7 +74,7 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 				allErrorPercentages = append(allErrorPercentages, e)
 			} else {
 
-				log.Error(fmt.Errorf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err))
+				log.Errorf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
 				errorPercentHasErrors = true
 			}
 		}

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -30,4 +31,37 @@ type ServiceLevel struct {
 type ServiceLevelIndicators struct {
 	ErrorPercent float64 `json:"error_percent"`
 	LatencyMs    int64   `json:"latency_ms"`
+
+	// used to record whether a particular property had
+	// error in it's retrieval process
+	errored [2]bool `json:"-"`
 }
+
+func (s *ServiceLevelIndicators) setErrorState(i indicatorErrType, b bool) *ServiceLevelIndicators {
+	s.errored[i] = b
+	return s
+}
+
+func (s *ServiceLevelIndicators) hasErrors(i indicatorErrType) bool {
+	return s.errored[i]
+}
+
+func (s *ServiceLevelIndicators) errorPerentString() string {
+	if s.errored[errPercentErr] {
+		return fmt.Sprintf("%.2f", s.ErrorPercent)
+	}
+	return "---"
+}
+
+func (s *ServiceLevelIndicators) latencyMsString() string {
+	if s.errored[latencyErr] {
+		return fmt.Sprintf("%dms", s.LatencyMs)
+	}
+	return "---"
+}
+
+// indicatorErrType - used to define indicator error types
+type indicatorErrType int
+
+var latencyErr indicatorErrType = 0
+var errPercentErr indicatorErrType = 1

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -47,17 +47,17 @@ func (s *ServiceLevelIndicators) hasErrors(i indicatorErrType) bool {
 }
 
 func (s *ServiceLevelIndicators) errorPerentString() string {
-	if s.errored[errPercentErr] {
-		return fmt.Sprintf("%.2f", s.ErrorPercent)
+	if s.hasErrors(errPercentErr) {
+		return "---"
 	}
-	return "---"
+	return fmt.Sprintf("%.2f", s.ErrorPercent)
 }
 
 func (s *ServiceLevelIndicators) latencyMsString() string {
-	if s.errored[latencyErr] {
-		return fmt.Sprintf("%dms", s.LatencyMs)
+	if s.hasErrors(latencyErr) {
+		return "---"
 	}
-	return "---"
+	return fmt.Sprintf("%dms", s.LatencyMs)
 }
 
 // indicatorErrType - used to define indicator error types

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -46,7 +46,7 @@ func (s *ServiceLevelIndicators) hasErrors(i indicatorErrType) bool {
 	return s.errored[i]
 }
 
-func (s *ServiceLevelIndicators) errorPerentString() string {
+func (s *ServiceLevelIndicators) errorPercentString() string {
 	if s.hasErrors(errPercentErr) {
 		return "---"
 	}

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -106,30 +106,37 @@ func tabbedoutput(r *Report, w io.Writer) {
 
 	var data [][]string
 	var actual string
-	var valueFromActual = func(actual, s string) string {
+	var delta = func(actual, s string) string {
 		if actual != "---" {
 			return s
 		}
 		return actual
 	}
 
+	var msg = func(actual, s string) string {
+		if actual != "---" {
+			return s
+		}
+		return color.Red("SLO could not be retrieved due to errors")
+	}
+
 	// set error budget data
-	actual = r.ServiceLevel.Actual.errorPerentString()
+	actual = r.ServiceLevel.Actual.errorPercentString()
 	if r.ServiceLevel.Delta.ErrorPercent > threshold {
 		data = append(data, []string{
 			fmt.Sprintf("%s Error Rate", iconEx),
 			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-			valueFromActual(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
-			valueFromActual(actual, fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)),
+			delta(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
+			msg(actual, fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)),
 		})
 	} else {
 		data = append(data, []string{
 			fmt.Sprintf("%s Error Rate", iconTick),
 			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-			valueFromActual(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
-			valueFromActual(actual, fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)),
+			delta(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
+			msg(actual, fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)),
 		})
 	}
 
@@ -140,16 +147,16 @@ func tabbedoutput(r *Report, w io.Writer) {
 			fmt.Sprintf("%s Latency", iconEx),
 			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-			valueFromActual(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			valueFromActual(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
+			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
+			msg(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
 		})
 	} else {
 		data = append(data, []string{
 			fmt.Sprintf("%s Latency", iconTick),
 			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-			valueFromActual(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			valueFromActual(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
+			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
+			msg(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
 		})
 	}
 

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -157,10 +157,3 @@ func tabbedoutput(r *Report, w io.Writer) {
 	// render table
 	table.Render()
 }
-
-// evaluate the Actual field in ServiceIndicator to check for
-// errors and return blank if any
-func evaluateActual() string {
-
-	return "---"
-}

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -52,25 +52,30 @@ func Write(format Format, r *Report, w io.Writer, l *logrus.Logger) {
 
 	switch format {
 	case JSON:
-		b, _ := json.MarshalIndent(r, "", "  ")
-		fmt.Fprintln(w, string(b))
+		if !r.ServiceLevel.Actual.hasErrors(errPercentErr) && !r.ServiceLevel.Actual.hasErrors(latencyErr) {
+			b, _ := json.MarshalIndent(r, "", "  ")
+			fmt.Fprintln(w, string(b))
+		}
 
 	case SimpleText:
 		fmt.Printf("SLO report: (last %s)\n", r.ObservationWindow.To.Sub(r.ObservationWindow.From))
-
-		if r.ServiceLevel.Delta.ErrorPercent > threshold {
-			msg := fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)
-			fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
-		} else {
-			msg := fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)
-			fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
+		if !r.ServiceLevel.Actual.hasErrors(errPercentErr) {
+			if r.ServiceLevel.Delta.ErrorPercent > threshold {
+				msg := fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)
+				fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
+			} else {
+				msg := fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)
+				fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
+			}
 		}
 
-		if r.ServiceLevel.Delta.LatencyMs > threshold {
-			msg := fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)
-			fmt.Printf("%s Latency: %vms. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.LatencyMs, msg)
-		} else {
-			fmt.Printf("%s Latency: %vms. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.LatencyMs, latencyValid)
+		if !r.ServiceLevel.Actual.hasErrors(latencyErr) {
+			if r.ServiceLevel.Delta.LatencyMs > threshold {
+				msg := fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)
+				fmt.Printf("%s Latency: %vms. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.LatencyMs, msg)
+			} else {
+				fmt.Printf("%s Latency: %vms. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.LatencyMs, latencyValid)
+			}
 		}
 
 	default:
@@ -101,9 +106,9 @@ func tabbedoutput(r *Report, w io.Writer) {
 
 	var data [][]string
 	var actual string
-	var delta = func(actual, d string) string {
+	var valueFromActual = func(actual, s string) string {
 		if actual != "---" {
-			return d
+			return s
 		}
 		return actual
 	}
@@ -115,16 +120,16 @@ func tabbedoutput(r *Report, w io.Writer) {
 			fmt.Sprintf("%s Error Rate", iconEx),
 			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-			delta(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
-			fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent),
+			valueFromActual(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
+			valueFromActual(actual, fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)),
 		})
 	} else {
 		data = append(data, []string{
 			fmt.Sprintf("%s Error Rate", iconTick),
 			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-			delta(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
-			fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent),
+			valueFromActual(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
+			valueFromActual(actual, fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)),
 		})
 	}
 
@@ -135,16 +140,16 @@ func tabbedoutput(r *Report, w io.Writer) {
 			fmt.Sprintf("%s Latency", iconEx),
 			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs),
+			valueFromActual(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
+			valueFromActual(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
 		})
 	} else {
 		data = append(data, []string{
 			fmt.Sprintf("%s Latency", iconTick),
 			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			latencyValid,
+			valueFromActual(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
+			valueFromActual(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
 		})
 	}
 

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -121,7 +121,6 @@ func tabbedoutput(r *Report, w io.Writer) {
 			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
 			delta(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
-			delta(actual, fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)),
 		})
 	} else {
 		data = append(data, []string{
@@ -129,7 +128,6 @@ func tabbedoutput(r *Report, w io.Writer) {
 			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
 			delta(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
-			delta(actual, fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)),
 		})
 	}
 
@@ -141,7 +139,6 @@ func tabbedoutput(r *Report, w io.Writer) {
 			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
 			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			delta(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
 		})
 	} else {
 		data = append(data, []string{
@@ -149,7 +146,6 @@ func tabbedoutput(r *Report, w io.Writer) {
 			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
 			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			delta(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
 		})
 	}
 

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -113,13 +113,6 @@ func tabbedoutput(r *Report, w io.Writer) {
 		return actual
 	}
 
-	var msg = func(actual, s string) string {
-		if actual != "---" {
-			return s
-		}
-		return color.Red("SLO could not be retrieved due to errors")
-	}
-
 	// set error budget data
 	actual = r.ServiceLevel.Actual.errorPercentString()
 	if r.ServiceLevel.Delta.ErrorPercent > threshold {
@@ -128,7 +121,7 @@ func tabbedoutput(r *Report, w io.Writer) {
 			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
 			delta(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
-			msg(actual, fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)),
+			delta(actual, fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)),
 		})
 	} else {
 		data = append(data, []string{
@@ -136,7 +129,7 @@ func tabbedoutput(r *Report, w io.Writer) {
 			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
 			delta(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
-			msg(actual, fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)),
+			delta(actual, fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)),
 		})
 	}
 
@@ -148,7 +141,7 @@ func tabbedoutput(r *Report, w io.Writer) {
 			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
 			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			msg(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
+			delta(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
 		})
 	} else {
 		data = append(data, []string{
@@ -156,7 +149,7 @@ func tabbedoutput(r *Report, w io.Writer) {
 			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
 			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			msg(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
+			delta(actual, fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)),
 		})
 	}
 

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -100,41 +100,50 @@ func tabbedoutput(r *Report, w io.Writer) {
 		color.Bold(color.Magenta("Delta")), ""})
 
 	var data [][]string
+	var actual string
+	var delta = func(actual, d string) string {
+		if actual != "---" {
+			return d
+		}
+		return actual
+	}
 
 	// set error budget data
+	actual = r.ServiceLevel.Actual.errorPerentString()
 	if r.ServiceLevel.Delta.ErrorPercent > threshold {
 		data = append(data, []string{
 			fmt.Sprintf("%s Error Rate", iconEx),
-			color.Bold(color.Red(fmt.Sprintf("%.2f", r.ServiceLevel.Actual.ErrorPercent))),
+			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-			fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent),
+			delta(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
 			fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent),
 		})
 	} else {
 		data = append(data, []string{
 			fmt.Sprintf("%s Error Rate", iconTick),
-			color.Bold(color.Green(fmt.Sprintf("%.2f", r.ServiceLevel.Actual.ErrorPercent))),
+			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-			fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent),
+			delta(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
 			fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent),
 		})
 	}
 
 	// set latency
+	actual = r.ServiceLevel.Actual.latencyMsString()
 	if r.ServiceLevel.Delta.LatencyMs > threshold {
 		data = append(data, []string{
 			fmt.Sprintf("%s Latency", iconEx),
-			color.Bold(color.Red(fmt.Sprintf("%dms", r.ServiceLevel.Actual.LatencyMs))),
+			color.Bold(color.IfTrueRed(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-			fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs),
+			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
 			fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs),
 		})
 	} else {
 		data = append(data, []string{
 			fmt.Sprintf("%s Latency", iconTick),
-			color.Bold(color.Green(fmt.Sprintf("%dms", r.ServiceLevel.Actual.LatencyMs))),
+			color.Bold(color.IfTrueGreen(actual != "---", actual)),
 			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-			fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs),
+			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
 			latencyValid,
 		})
 	}
@@ -147,4 +156,11 @@ func tabbedoutput(r *Report, w io.Writer) {
 
 	// render table
 	table.Render()
+}
+
+// evaluate the Actual field in ServiceIndicator to check for
+// errors and return blank if any
+func evaluateActual() string {
+
+	return "---"
 }

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/AlecAivazis/survey/v2 v2.2.7 h1:5NbxkF4RSKmpywYdcRgUmos1o+roJY8duCLZXbVjoig=
-github.com/AlecAivazis/survey/v2 v2.2.7/go.mod h1:9DYvHgXtiXm6nCn+jXnOXLKbH+Yo9u8fAS/SduGdoPk=
 github.com/AlecAivazis/survey/v2 v2.2.9 h1:LWvJtUswz/W9/zVVXELrmlvdwWcKE60ZAw0FWV9vssk=
 github.com/AlecAivazis/survey/v2 v2.2.9/go.mod h1:9DYvHgXtiXm6nCn+jXnOXLKbH+Yo9u8fAS/SduGdoPk=
 github.com/Azure/go-autorest/autorest v0.9.0 h1:MRvx8gncNaXJqOoLmhNjUAKh33JJF8LyxPhomEtOsjs=
@@ -488,8 +486,6 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -641,8 +637,6 @@ golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210314195730-07df6a141424/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=


### PR DESCRIPTION
This PR adds support for checking errors against Service Level Indicators and returning empty values (`---`) in the report when errors are detected.

For example:
![image](https://user-images.githubusercontent.com/4018554/114527730-353d9380-9c40-11eb-81a9-65d807edf465.png)





_Tabbed and Simple Text outputs, will print partial results if a particular Objective has an error. JSON output will not be returned if any errors are detected._

Resolves #144
