### PR TITLE
Update manifest

### DIFF
--- a/cmd/reliably/slo/init/cmd.go
+++ b/cmd/reliably/slo/init/cmd.go
@@ -82,14 +82,26 @@ func populateManifestInteractively(m *manifest.Manifest) {
 
 	var s manifest.Service
 
-	s.Objective = manifest.ServiceLevelObjective{
-		ErrorBudgetPercent: question.WithFloat64Answer("What percentage of requests to your service is it ok to have fail? This will be your 'error budget'.", 0, 100),
-		Latency:            question.WithDurationAnswer("What is the maximum request-response latency you want from this service (in milliseconds)?"),
+	// s.Type = manifest.Service.Type{}
+
+	sloType := question.WithSingleChoiceAnswer("What type of SLO do you want to declare?", "Availability", "Latency")
+	s.Type = sanitizeString(sloType)
+
+	if s.Type == "latency" {
+		s.Threshold = question.WithDurationAnswer("What is your latency threshold (in milliseconds)?")
 	}
 
-	s.Resources = []manifest.ServiceResource{}
+	s.Objective = question.WithFloat64Answer("What is your target for this SLO?'.", 0, 100)
 
-	do := question.WithBoolAnswer("Do you want to add a service resource?")
+
+	// s.Objective = manifest.ServiceLevelObjective{
+	// 	ErrorBudgetPercent: question.WithFloat64Answer("What percentage of requests to your service is it ok to have fail? This will be your 'error budget'.", 0, 100),
+	// 	Latency:            question.WithDurationAnswer("What is the maximum request-response latency you want from this service (in milliseconds)?"),
+	// }
+
+	// s.Resources = []manifest.ServiceResource{}
+
+	do := question.WithBoolAnswer("Do you want to add an SLI to measure this SLO?")
 	if do {
 		providers := []string{}
 		for key := range providersMap {
@@ -98,7 +110,7 @@ func populateManifestInteractively(m *manifest.Manifest) {
 		sort.Strings(providers) // sorts slice in-place
 
 		for do {
-			providerFullName := question.WithSingleChoiceAnswer("What is the name of the resource provider?", providers...)
+			providerFullName := question.WithSingleChoiceAnswer("On which cloud provider?", providers...)
 			provider := providersMap[providerFullName]
 			id := getResourceIDForProvider(provider)
 
@@ -107,10 +119,10 @@ func populateManifestInteractively(m *manifest.Manifest) {
 				ID:       id,
 			})
 
-			do = question.WithBoolAnswer("Do you want to add another dependency?")
+			do = question.WithBoolAnswer("Do you want to add another SLI?")
 		}
 
-		s.Name = question.WithStringAnswer("SLO/Service name?")
+		s.Name = question.WithStringAnswer("What is the name of this SLO?")
 	}
 	m.ServiceLevel = append(m.ServiceLevel, &s)
 	fmt.Println(color.Green(fmt.Sprintf("SLO/Service (%s) added", s.Name)))
@@ -129,7 +141,7 @@ func getResourceIDForProvider(provider string) string {
 		{
 			projectID := question.WithStringAnswer("What is the GCP project ID?")
 			resourceType := question.WithSingleChoiceAnswer("What is the 'type' of the resource?", googleResourceTypes...)
-			sanitizedResourceType := sanitizeResourceType(resourceType)
+			sanitizedResourceType := sanitizeString(resourceType)
 			resourceName := question.WithStringAnswer("What is the name of resource?")
 			return fmt.Sprintf("%s/%s/%s", projectID, sanitizedResourceType, resourceName)
 		}
@@ -138,6 +150,6 @@ func getResourceIDForProvider(provider string) string {
 	}
 }
 
-func sanitizeResourceType(s string) string {
+func sanitizeString(s string) string {
 	return strings.ToLower(strings.ReplaceAll(s, " ", "-"))
 }

--- a/cmd/reliably/slo/init/cmd.go
+++ b/cmd/reliably/slo/init/cmd.go
@@ -84,22 +84,30 @@ func populateManifestInteractively(m *manifest.Manifest) {
 
 	// s.Type = manifest.Service.Type{}
 
-	sloType := question.WithSingleChoiceAnswer("What type of SLO do you want to declare?", "Availability", "Latency")
-	s.Type = sanitizeString(sloType)
+	s.Name = question.WithStringAnswer("What is the name of the service you want to declare SLOs for?")
 
-	if s.Type == "latency" {
-		s.Threshold = question.WithDurationAnswer("What is your latency threshold (in milliseconds)?")
+	declareSLOForService(&s)
+
+	m.Services = append(m.Services, &s)
+	fmt.Println(color.Green(fmt.Sprintf("Service '%s' added", s.Name)))
+
+	if question.WithBoolAnswer("Do you want to add another Service?") {
+		populateManifestInteractively(m)
 	}
 
-	s.Objective = question.WithFloat64Answer("What is your target for this SLO (in %)?'.", 0, 100)
+}
 
+func declareSLOForService(s *manifest.Service) {
+	var sl manifest.ServiceLevel
 
-	// s.Objective = manifest.ServiceLevelObjective{
-	// 	ErrorBudgetPercent: question.WithFloat64Answer("What percentage of requests to your service is it ok to have fail? This will be your 'error budget'.", 0, 100),
-	// 	Latency:            question.WithDurationAnswer("What is the maximum request-response latency you want from this service (in milliseconds)?"),
-	// }
+	slType := question.WithSingleChoiceAnswer("What type of SLO do you want to declare?", "Availability", "Latency")
+	sl.Type = sanitizeString(slType)
 
-	// s.Resources = []manifest.ServiceResource{}
+	if sl.Type == "latency" {
+		sl.Threshold = question.WithDurationAnswer("What is your latency threshold (in milliseconds)?")
+	}
+
+	sl.Objective = question.WithFloat64Answer("What is your target for this SLO (in %)?'.", 0, 100)
 
 	do := question.WithBoolAnswer("Do you want to add an SLI to measure this SLO?")
 	if do {
@@ -114,23 +122,21 @@ func populateManifestInteractively(m *manifest.Manifest) {
 			provider := providersMap[providerFullName]
 			id := getResourceIDForProvider(provider)
 
-			s.Resources = append(s.Resources, manifest.ServiceResource{
+			sl.Indicators = append(sl.Indicators, manifest.ServiceLevelIndicator{
 				Provider: provider,
 				ID:       id,
 			})
 
 			do = question.WithBoolAnswer("Do you want to add another SLI?")
 		}
-
-		s.Name = question.WithStringAnswer("What is the name of this SLO?")
 	}
-	m.ServiceLevel = append(m.ServiceLevel, &s)
-	fmt.Println(color.Green(fmt.Sprintf("SLO/Service (%s) added", s.Name)))
+	sl.Name = question.WithStringAnswer("What is the name of this SLO?")
+	s.ServiceLevels = append(s.ServiceLevels, &sl)
+	fmt.Println(color.Green(fmt.Sprintf("SLO '%s' added to Service '%s'", sl.Name, s.Name)))
 
 	if question.WithBoolAnswer("Do you want to add another SLO?") {
-		populateManifestInteractively(m)
+		declareSLOForService(s)
 	}
-
 }
 
 func getResourceIDForProvider(provider string) string {

--- a/cmd/reliably/slo/init/cmd.go
+++ b/cmd/reliably/slo/init/cmd.go
@@ -91,7 +91,7 @@ func populateManifestInteractively(m *manifest.Manifest) {
 		s.Threshold = question.WithDurationAnswer("What is your latency threshold (in milliseconds)?")
 	}
 
-	s.Objective = question.WithFloat64Answer("What is your target for this SLO?'.", 0, 100)
+	s.Objective = question.WithFloat64Answer("What is your target for this SLO (in %)?'.", 0, 100)
 
 
 	// s.Objective = manifest.ServiceLevelObjective{

--- a/cmd/reliably/slo/init/cmd.go
+++ b/cmd/reliably/slo/init/cmd.go
@@ -104,7 +104,8 @@ func declareSLOForService(s *manifest.Service) {
 	sl.Type = sanitizeString(slType)
 
 	if sl.Type == "latency" {
-		sl.Threshold = question.WithDurationAnswer("What is your latency threshold (in milliseconds)?")
+		threshold := question.WithDurationAnswer("What is your latency threshold (in milliseconds)?")
+		sl.Criteria = &manifest.LatencyCriteria{Threshold: threshold}
 	}
 
 	sl.Objective = question.WithFloat64Answer("What is your target for this SLO (in %)?", 0, 100)

--- a/cmd/reliably/slo/init/cmd.go
+++ b/cmd/reliably/slo/init/cmd.go
@@ -107,7 +107,7 @@ func declareSLOForService(s *manifest.Service) {
 		sl.Threshold = question.WithDurationAnswer("What is your latency threshold (in milliseconds)?")
 	}
 
-	sl.Objective = question.WithFloat64Answer("What is your target for this SLO (in %)?'.", 0, 100)
+	sl.Objective = question.WithFloat64Answer("What is your target for this SLO (in %)?", 0, 100)
 
 	do := question.WithBoolAnswer("Do you want to add an SLI to measure this SLO?")
 	if do {

--- a/cmd/reliably/slo/report/cmd.go
+++ b/cmd/reliably/slo/report/cmd.go
@@ -106,7 +106,7 @@ func sendReportToReliably(r *report.Report) error {
 // watch - continously fetch and update report
 // and output to terminal
 func watch(manifestPath string) error {
-	rChan := make(chan []*report.Report, 5)
+	rChan := make(chan *report.Report, 5)
 	errChan := make(chan error, 1)
 	done := make(chan struct{})
 	c := make(chan os.Signal)
@@ -130,11 +130,11 @@ func watch(manifestPath string) error {
 				errChan <- errors.New("An error occured while attempting to load the manifest")
 			}
 
-			reports, err := report.FromManifest(m)
+			report, err := report.FromManifest(m)
 			if err != nil {
 				errChan <- err
 			}
-			rChan <- reports
+			rChan <- report
 		}
 	}()
 
@@ -148,12 +148,10 @@ func watch(manifestPath string) error {
 	// print stuff
 	for {
 		select {
-		case reports := <-rChan:
+		case r := <-rChan:
 			clearScreen()
-			fmt.Println(color.Magenta("Watching SLO report (3s)"))
-			for _, r := range reports {
-				report.Write(report.TABBED, r, os.Stdout, log.StandardLogger())
-			}
+			fmt.Println(color.Magenta("Watching SLO report (3s)"), "Press CTRL+C to exit")
+			report.Write(report.TABBED, r, os.Stdout, log.StandardLogger())
 
 		case err := <-errChan:
 			return err

--- a/cmd/reliably/slo/report/cmd.go
+++ b/cmd/reliably/slo/report/cmd.go
@@ -60,7 +60,7 @@ func runE(_ *cobra.Command, _ []string) error {
 		return errors.New("An error occured while attempting to load the manifest")
 	}
 
-	reports, err := report.FromManifest(m)
+	r, err := report.FromManifest(m)
 	if err != nil {
 		return err
 	}
@@ -78,9 +78,7 @@ func runE(_ *cobra.Command, _ []string) error {
 		format = report.SimpleText
 	}
 
-	for _, r := range reports {
-		report.Write(format, r, os.Stdout, log.StandardLogger())
-	}
+	report.Write(format, r, os.Stdout, log.StandardLogger())
 
 	if outputPath != "" {
 		if !strings.HasSuffix(outputPath, ".json") {
@@ -88,7 +86,7 @@ func runE(_ *cobra.Command, _ []string) error {
 			return nil
 		}
 
-		bytes, err := json.Marshal(reports)
+		bytes, err := json.Marshal(r)
 		if err != nil {
 			return nil
 		}

--- a/core/iostreams/iostreams.go
+++ b/core/iostreams/iostreams.go
@@ -21,6 +21,10 @@ func FailureIcon() string {
 	return color.Red("✕")
 }
 
+func UnknownIcon() string {
+	return color.Magenta("?")
+}
+
 type IOStreams struct {
 	In     io.ReadCloser
 	Out    io.Writer

--- a/core/manifest/load_test.go
+++ b/core/manifest/load_test.go
@@ -28,29 +28,57 @@ func TestLoad(t *testing.T) {
 				path: dummyReliablyYamlManifestPath,
 			},
 			want: &Manifest{
-				ServiceLevel: []*Service{&Service{
-					Objective: ServiceLevelObjective{
-						Latency:            core.Duration{Duration: 100 * time.Millisecond},
-						ErrorBudgetPercent: 0.5,
-					},
-					Resources: []ServiceResource{
-						{
-							Provider: "abc",
-							ID:       "123",
+				Services: []*Service{
+					&Service{
+						Name: "Service A",
+						ServiceLevels: []*ServiceLevel{
+							&ServiceLevel{
+								Name: "Service A Availability",
+								Type: "availability",
+								Objective: 99,
+								Indicators: []ServiceLevelIndicator{
+									{
+										Provider: "aws",
+										ID: "arn1",
+									},
+									{
+										Provider: "gcp",
+										ID: "uri",
+									},
+								},
+							},
+							&ServiceLevel{
+								Name: "Service A Latency",
+								Type: "latency",
+								Threshold: core.Duration{Duration: 300 * time.Millisecond},
+								Objective: 99,
+								Indicators: []ServiceLevelIndicator{
+									{
+										Provider: "aws",
+										ID: "arn2",
+									},
+								},
+							},
 						},
-						{
-							Provider: "xyz",
-							ID:       "456",
-						},
+						Dependencies: []string{},
 					},
-				}},
-				Dependencies: []string{
-					"some service",
-					"some other service",
-				},
-				Tags: map[string]string{
-					"team":   "abc",
-					"domain": "xyz",
+					&Service{
+						Name: "Service B",
+						ServiceLevels: []*ServiceLevel{
+							&ServiceLevel{
+								Name: "Service B Availability",
+								Type: "availability",
+								Objective: 99,
+								Indicators: []ServiceLevelIndicator{
+									{
+										Provider: "aws",
+										ID: "arn3",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
 				},
 			},
 			wantErr: false,
@@ -61,29 +89,57 @@ func TestLoad(t *testing.T) {
 				path: dummyReliablyJsonManifestPath,
 			},
 			want: &Manifest{
-				ServiceLevel: []*Service{&Service{
-					Objective: ServiceLevelObjective{
-						Latency:            core.Duration{Duration: 100 * time.Millisecond},
-						ErrorBudgetPercent: 0.5,
-					},
-					Resources: []ServiceResource{
-						{
-							Provider: "abc",
-							ID:       "123",
+				Services: []*Service{
+					&Service{
+						Name: "Service A",
+						ServiceLevels: []*ServiceLevel{
+							&ServiceLevel{
+								Name: "Service A Availability",
+								Type: "availability",
+								Objective: 99,
+								Indicators: []ServiceLevelIndicator{
+									{
+										Provider: "aws",
+										ID: "arn1",
+									},
+									{
+										Provider: "gcp",
+										ID: "uri",
+									},
+								},
+							},
+							&ServiceLevel{
+								Name: "Service A Latency",
+								Type: "latency",
+								Threshold: core.Duration{Duration: 300 * time.Millisecond},
+								Objective: 99,
+								Indicators: []ServiceLevelIndicator{
+									{
+										Provider: "aws",
+										ID: "arn2",
+									},
+								},
+							},
 						},
-						{
-							Provider: "xyz",
-							ID:       "456",
-						},
+						Dependencies: []string{},
 					},
-				}},
-				Dependencies: []string{
-					"some service",
-					"some other service",
-				},
-				Tags: map[string]string{
-					"team":   "abc",
-					"domain": "xyz",
+					&Service{
+						Name: "Service B",
+						ServiceLevels: []*ServiceLevel{
+							&ServiceLevel{
+								Name: "Service B Availability",
+								Type: "availability",
+								Objective: 99,
+								Indicators: []ServiceLevelIndicator{
+									{
+										Provider: "aws",
+										ID: "arn3",
+									},
+								},
+							},
+						},
+						Dependencies: []string{},
+					},
 				},
 			},
 			wantErr: false,
@@ -115,38 +171,35 @@ func TestLoad(t *testing.T) {
 				return
 			}
 
-			for serviceIndex, s := range tt.want.ServiceLevel {
-				if !reflect.DeepEqual(s.Objective, got.ServiceLevel[serviceIndex].Objective) {
-					t.Errorf("Wanted Service.Objective to be %v but was %v", s.Objective, got.ServiceLevel[serviceIndex].Objective)
+			for serviceIndex, s := range tt.want.Services {
+				if !reflect.DeepEqual(s.ServiceLevels, got.Services[serviceIndex].ServiceLevels) {
+					t.Errorf("Wanted Service.ServiceLevels to be %v but was %v", s.ServiceLevels, got.Services[serviceIndex].ServiceLevels)
 					return
 				}
 
-				if len(s.Resources) == len(got.ServiceLevel[serviceIndex].Resources) {
-					for i, r := range tt.want.ServiceLevel[serviceIndex].Resources {
-						if r.ID != got.ServiceLevel[serviceIndex].Resources[i].ID {
-							t.Errorf("%v != %v", r.ID, got.ServiceLevel[serviceIndex].Resources[i].ID)
+				if len(s.ServiceLevels) == len(got.Services[serviceIndex].ServiceLevels) {
+					for i, sl := range tt.want.Services[serviceIndex].ServiceLevels {
+						if sl.Name != got.Services[serviceIndex].ServiceLevels[i].Name {
+							t.Errorf("%v != %v", sl.Name, got.Services[serviceIndex].ServiceLevels[i].Name)
 							return
 						}
 
-						if r.Provider != got.ServiceLevel[serviceIndex].Resources[i].Provider {
-							t.Errorf("%v != %v", r.Provider, got.ServiceLevel[serviceIndex].Resources[i].Provider)
-							return
+						for i2, sli := range tt.want.Services[serviceIndex].ServiceLevels[i].Indicators {
+							if sli.ID != got.Services[serviceIndex].ServiceLevels[i].Indicators[i2].ID {
+								t.Errorf("%v != %v", sli.ID, got.Services[serviceIndex].ServiceLevels[i].Indicators[i2].ID)
+								return
+							}
 						}
 					}
 				} else {
-					t.Errorf("Wanted Service.Resources to be %v but was %v", len(s.Resources), len(got.ServiceLevel[serviceIndex].Resources))
+					t.Errorf("Wanted Service.Resources to be %v but was %v", len(s.ServiceLevels), len(got.Services[serviceIndex].ServiceLevels))
 					return
 				}
-			}
 
-			if !reflect.DeepEqual(tt.want.Dependencies, got.Dependencies) {
-				t.Errorf("Wanted Dependencies to be %v but got %v", tt.want.Dependencies, got.Dependencies)
-				return
-			}
-
-			if !reflect.DeepEqual(tt.want.Tags, got.Tags) {
-				t.Errorf("Wanted Tags to be %v but got %v", tt.want.Tags, got.Tags)
-				return
+				if !reflect.DeepEqual(s.Dependencies, got.Services[serviceIndex].Dependencies) {
+					t.Errorf("Wanted Dependencies to be %v but got %v", s.Dependencies, got.Services[serviceIndex].Dependencies)
+					return
+				}
 			}
 		})
 	}

--- a/core/manifest/load_test.go
+++ b/core/manifest/load_test.go
@@ -33,29 +33,31 @@ func TestLoad(t *testing.T) {
 						Name: "Service A",
 						ServiceLevels: []*ServiceLevel{
 							&ServiceLevel{
-								Name: "Service A Availability",
-								Type: "availability",
+								Name:      "Service A Availability",
+								Type:      "availability",
 								Objective: 99,
 								Indicators: []ServiceLevelIndicator{
 									{
 										Provider: "aws",
-										ID: "arn1",
+										ID:       "arn1",
 									},
 									{
 										Provider: "gcp",
-										ID: "uri",
+										ID:       "uri",
 									},
 								},
 							},
 							&ServiceLevel{
 								Name: "Service A Latency",
 								Type: "latency",
-								Threshold: core.Duration{Duration: 300 * time.Millisecond},
+								Criteria: LatencyCriteria{
+									Threshold: core.Duration{Duration: 300 * time.Millisecond},
+								},
 								Objective: 99,
 								Indicators: []ServiceLevelIndicator{
 									{
 										Provider: "aws",
-										ID: "arn2",
+										ID:       "arn2",
 									},
 								},
 							},
@@ -66,13 +68,13 @@ func TestLoad(t *testing.T) {
 						Name: "Service B",
 						ServiceLevels: []*ServiceLevel{
 							&ServiceLevel{
-								Name: "Service B Availability",
-								Type: "availability",
+								Name:      "Service B Availability",
+								Type:      "availability",
 								Objective: 99,
 								Indicators: []ServiceLevelIndicator{
 									{
 										Provider: "aws",
-										ID: "arn3",
+										ID:       "arn3",
 									},
 								},
 							},
@@ -94,29 +96,31 @@ func TestLoad(t *testing.T) {
 						Name: "Service A",
 						ServiceLevels: []*ServiceLevel{
 							&ServiceLevel{
-								Name: "Service A Availability",
-								Type: "availability",
+								Name:      "Service A Availability",
+								Type:      "availability",
 								Objective: 99,
 								Indicators: []ServiceLevelIndicator{
 									{
 										Provider: "aws",
-										ID: "arn1",
+										ID:       "arn1",
 									},
 									{
 										Provider: "gcp",
-										ID: "uri",
+										ID:       "uri",
 									},
 								},
 							},
 							&ServiceLevel{
 								Name: "Service A Latency",
 								Type: "latency",
-								Threshold: core.Duration{Duration: 300 * time.Millisecond},
+								Criteria: LatencyCriteria{
+									Threshold: core.Duration{Duration: 300 * time.Millisecond},
+								},
 								Objective: 99,
 								Indicators: []ServiceLevelIndicator{
 									{
 										Provider: "aws",
-										ID: "arn2",
+										ID:       "arn2",
 									},
 								},
 							},
@@ -127,13 +131,13 @@ func TestLoad(t *testing.T) {
 						Name: "Service B",
 						ServiceLevels: []*ServiceLevel{
 							&ServiceLevel{
-								Name: "Service B Availability",
-								Type: "availability",
+								Name:      "Service B Availability",
+								Type:      "availability",
 								Objective: 99,
 								Indicators: []ServiceLevelIndicator{
 									{
 										Provider: "aws",
-										ID: "arn3",
+										ID:       "arn3",
 									},
 								},
 							},

--- a/core/manifest/types.go
+++ b/core/manifest/types.go
@@ -15,7 +15,7 @@ type (
 		// CI           *ContinuousIntegrationInfo `yaml:"ci,omitempty" json:"ci,omitempty"`
 		// Hosting      *Hosting          `yaml:"hosting,omitempty" json:"hosting,omitempty"`
 		// IAC          *IAC              `yaml:"infrastructure_as_code,omitempty" json:"infrastructure_as_code,omitempty"`
-		Tags map[string]string `yaml:"tags,omitempty" json:"tags,omitempty"`
+		// Tags map[string]string `yaml:"tags,omitempty" json:"tags,omitempty"`
 	}
 
 	// AppInfo struct {

--- a/core/manifest/types.go
+++ b/core/manifest/types.go
@@ -9,7 +9,7 @@ import (
 type (
 	Manifest struct {
 		// App          *AppInfo          `yaml:"app" json:"app"`
-		ServiceLevel []*Service `yaml:"slo" json:"slo"`
+		Services []*Service `yaml:"services" json:"services"`
 		// Dependencies []string   `yaml:"dependencies" json:"dependencies"`
 		// ServiceLevel *ServiceLevel     `yaml:"service_level,omitempty" json:"service_level,omitempty"`
 		// CI           *ContinuousIntegrationInfo `yaml:"ci,omitempty" json:"ci,omitempty"`
@@ -18,60 +18,73 @@ type (
 		Tags map[string]string `yaml:"tags,omitempty" json:"tags,omitempty"`
 	}
 
-	AppInfo struct {
-		Name       string `yaml:"name" json:"name"`
-		Owner      string `yaml:"owner" json:"owner"`
-		Repository string `yaml:"repo" json:"repo"`
-	}
+	// AppInfo struct {
+	// 	Name       string `yaml:"name" json:"name"`
+	// 	Owner      string `yaml:"owner" json:"owner"`
+	// 	Repository string `yaml:"repo" json:"repo"`
+	// }
 
 	Service struct {
-		Name				 string             `yaml:"name" json:"name"`
-		Type				 string							`yaml:"type" json:"type"`
-		Threshold		 core.Duration			`yaml:"threshold" json:"threshold"`
-		Objective 	 float64						`yaml:"objective" json:"objective"`
-		Resources 	 []ServiceResource  `yaml:"sli" json:"sli"`
-		Dependencies []string						`yaml:"dependencies" json:"dependencies"`
+		Name					string        	`yaml:"name" json:"name"`
+		ServiceLevels	[]*ServiceLevel `yaml:"service-levels" json:"service-levels"`
+		Dependencies	[]string				`yaml:"dependencies" json:"dependencies"`
 	}
 
-	ServiceLevelObjective struct {
-		Latency            core.Duration `yaml:"latency" json:"latency"`
-		ErrorBudgetPercent float64       `yaml:"error_budget_percent" json:"error_budget_percent"`
+	ServiceLevel struct {
+		Name				 string            			 `yaml:"name" json:"name"`
+		Type				 string									 `yaml:"type" json:"type"`
+		Threshold		 core.Duration					 `yaml:"threshold,omitempty" json:"threshold,omitempty"`
+		Objective 	 float64								 `yaml:"slo" json:"slo"`
+		Indicators 	 []ServiceLevelIndicator `yaml:"sli" json:"sli"`
 	}
 
-	ServiceResource struct {
+	// ServiceLevelObjective struct {
+	// 	Latency            core.Duration `yaml:"latency" json:"latency"`
+	// 	ErrorBudgetPercent float64       `yaml:"error_budget_percent" json:"error_budget_percent"`
+	// }
+
+	ServiceLevelIndicator struct {
 		ID       string `yaml:"id" json:"id"`
 		Provider string `yaml:"provider" json:"provider"`
 	}
 
-	ServiceLevel struct {
-		Availability       float64       `yaml:"availability" json:"availability"`
-		Latency            core.Duration `yaml:"latency" json:"latency"`
-		ErrorBudgetPercent float64       `yaml:"error_budget_pc" json:"error_budget_pc"`
-	}
+	// ServiceLevel struct {
+	// 	Availability       float64       `yaml:"availability" json:"availability"`
+	// 	Latency            core.Duration `yaml:"latency" json:"latency"`
+	// 	ErrorBudgetPercent float64       `yaml:"error_budget_pc" json:"error_budget_pc"`
+	// }
 
-	ContinuousIntegrationInfo struct {
-		Type string `yaml:"type" json:"type"`
-	}
+	// ContinuousIntegrationInfo struct {
+	// 	Type string `yaml:"type" json:"type"`
+	// }
 
-	Hosting struct {
-		Provider string `yaml:"provider" json:"provider"`
-	}
+	// Hosting struct {
+	// 	Provider string `yaml:"provider" json:"provider"`
+	// }
 
-	IAC struct {
-		Type string `yame:"type" json:"type"`
-		Root string `yaml:"root" json:"root"`
-	}
+	// IAC struct {
+	// 	Type string `yame:"type" json:"type"`
+	// 	Root string `yaml:"root" json:"root"`
+	// }
 )
 
 // Validate - validate manifest
 func (m *Manifest) Validate() error {
 	// check slo names are duplicated
-	names := make(map[string]struct{}, len(m.ServiceLevel))
-	for _, s := range m.ServiceLevel {
-		if _, exists := names[s.Name]; exists {
-			return fmt.Errorf("duplicate SLO Name detected: [%s]", s.Name)
+	servicesNames := make(map[string]struct{}, len(m.Services))
+	for _, s := range m.Services {
+		if _, exists := servicesNames[s.Name]; exists {
+			return fmt.Errorf("Duplicate Service Name detected: [%s]", s.Name)
 		}
-		names[s.Name] = struct{}{}
+		servicesNames[s.Name] = struct{}{}
+		
+		sloNames := make(map[string]struct{}, len (s.ServiceLevels))
+		for _, sl := range s.ServiceLevels {
+			if _, exists2 := sloNames[sl.Name]; exists2 {
+				return fmt.Errorf("Duplicate Service Level Name detected in Service %s: [%s]", s.Name, sl.Name)
+			}
+			sloNames[sl.Name] = struct{}{}
+		}
 	}
 
 	return nil

--- a/core/manifest/types.go
+++ b/core/manifest/types.go
@@ -25,17 +25,28 @@ type (
 	// }
 
 	Service struct {
-		Name					string        	`yaml:"name" json:"name"`
-		ServiceLevels	[]*ServiceLevel `yaml:"service-levels" json:"service-levels"`
-		Dependencies	[]string				`yaml:"dependencies" json:"dependencies"`
+		Name          string          `yaml:"name" json:"name"`
+		ServiceLevels []*ServiceLevel `yaml:"service-levels" json:"service-levels"`
+		Dependencies  []string        `yaml:"dependencies" json:"dependencies"`
 	}
 
 	ServiceLevel struct {
-		Name				 string            			 `yaml:"name" json:"name"`
-		Type				 string									 `yaml:"type" json:"type"`
-		Threshold		 core.Duration					 `yaml:"threshold,omitempty" json:"threshold,omitempty"`
-		Objective 	 float64								 `yaml:"slo" json:"slo"`
-		Indicators 	 []ServiceLevelIndicator `yaml:"sli" json:"sli"`
+		Name     string      `yaml:"name" json:"name"`
+		Type     string      `yaml:"type" json:"type"`
+		Criteria interface{} `yaml:"criteria,omitempty" json:"criteria,omitempty"`
+		//Threshold  core.Duration           `yaml:"threshold,omitempty" json:"threshold,omitempty"`
+		Objective  float64                 `yaml:"slo" json:"slo"`
+		Indicators []ServiceLevelIndicator `yaml:"sli" json:"sli"`
+	}
+
+	Criteria struct {
+	}
+
+	LatencyCriteria struct {
+		Threshold core.Duration `yaml:"threshold,omitempty" json:"threshold,omitempty"`
+	}
+
+	AvailabilityCriteria struct {
 	}
 
 	// ServiceLevelObjective struct {
@@ -77,8 +88,8 @@ func (m *Manifest) Validate() error {
 			return fmt.Errorf("Duplicate Service Name detected: [%s]", s.Name)
 		}
 		servicesNames[s.Name] = struct{}{}
-		
-		sloNames := make(map[string]struct{}, len (s.ServiceLevels))
+
+		sloNames := make(map[string]struct{}, len(s.ServiceLevels))
 		for _, sl := range s.ServiceLevels {
 			if _, exists2 := sloNames[sl.Name]; exists2 {
 				return fmt.Errorf("Duplicate Service Level Name detected in Service %s: [%s]", s.Name, sl.Name)
@@ -86,6 +97,44 @@ func (m *Manifest) Validate() error {
 			sloNames[sl.Name] = struct{}{}
 		}
 	}
+
+	return nil
+}
+func (sl *ServiceLevel) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+
+	type Alias ServiceLevel
+
+	// We unmarshal the ServiceLevel into the object
+	var asl Alias
+	if err := unmarshal(&asl); err != nil {
+		fmt.Println("error unmarshall")
+		return err
+	}
+
+	// assign the unmarshaled content to the current service level pointer
+	*sl = ServiceLevel(asl)
+
+	// Then we make a second unmarshalling
+	// to create the right Criteria structure
+	// depending on the service level type
+	var criteria interface{}
+	switch sl.Type {
+	case "latency":
+
+		lc := struct {
+			Criteria LatencyCriteria `json:"criteria"`
+		}{}
+
+		if err := unmarshal(&lc); err == nil {
+			criteria = lc.Criteria
+		}
+
+	case "availability":
+	default:
+	}
+
+	// assign the parsed criteria to the current service level
+	sl.Criteria = criteria
 
 	return nil
 }

--- a/core/manifest/types.go
+++ b/core/manifest/types.go
@@ -10,7 +10,7 @@ type (
 	Manifest struct {
 		// App          *AppInfo          `yaml:"app" json:"app"`
 		ServiceLevel []*Service `yaml:"slo" json:"slo"`
-		Dependencies []string   `yaml:"dependencies" json:"dependencies"`
+		// Dependencies []string   `yaml:"dependencies" json:"dependencies"`
 		// ServiceLevel *ServiceLevel     `yaml:"service_level,omitempty" json:"service_level,omitempty"`
 		// CI           *ContinuousIntegrationInfo `yaml:"ci,omitempty" json:"ci,omitempty"`
 		// Hosting      *Hosting          `yaml:"hosting,omitempty" json:"hosting,omitempty"`
@@ -25,9 +25,12 @@ type (
 	}
 
 	Service struct {
-		Name      string                `yaml:"name" json:"name"`
-		Objective ServiceLevelObjective `yaml:"objective" json:"objective"`
-		Resources []ServiceResource     `yaml:"resources" json:"resources"`
+		Name				 string             `yaml:"name" json:"name"`
+		Type				 string							`yaml:"type" json:"type"`
+		Threshold		 core.Duration			`yaml:"threshold" json:"threshold"`
+		Objective 	 float64						`yaml:"objective" json:"objective"`
+		Resources 	 []ServiceResource  `yaml:"sli" json:"sli"`
+		Dependencies []string						`yaml:"dependencies" json:"dependencies"`
 	}
 
 	ServiceLevelObjective struct {

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -31,6 +31,9 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 		return reports, fmt.Errorf("nil manifest.Manifest received")
 	}
 
+	to := time.Now()
+	from := to.Add(-oneDay)
+
 	for _, s := range m.Services {
 		if s == nil {
 			return nil, go_errors.New("I don't know anything about your services. Run `reliably slo init` to tell me.")
@@ -42,64 +45,107 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 
 		// Also need to check if there are SLIs in each Service Level
 
-		r := Report{Name: s.Name}
+		sls := make([]*ServiceLevel, 0)
+		r := Report{Name: s.Name, ServiceLevels: sls}
 
 		r.APIVersion = apiVersion
 		r.Timestamp = timestampFn()
 		r.Dependencies = []string{}
 
-		allLatency := []float64{}
-		allErrorPercentages := []float64{}
+		//allLatency := []float64{}
+		//allErrorPercentages := []float64{}
 
-		var latencyHasErrors = false
-		var errorPercentHasErrors = false
+		allValues := []float64{}
+		valuesHasError := false
+
+		//var latencyHasErrors = false
+		//var errorPercentHasErrors = false
 
 		for _, sl := range s.ServiceLevels {
+
+			fmt.Println(sl.Name, sl.Type, sl.Objective, sl.Threshold)
+
 			for _, sli := range sl.Indicators {
 				provider, err := getProviderForResource(sli.Provider)
 				if err != nil {
 					return nil, fmt.Errorf("an error occured while getting a provider for sli: %s => %s", sli.Provider, err)
 				}
 
-				to := time.Now()
-				from := to.Add(-oneDay)
-				r.ObservationWindow.To = to
-				r.ObservationWindow.From = from
-
-				if l, err := provider.Get99PercentLatencyMetricForResource(sli.ID, from, to); err == nil {
-					allLatency = append(allLatency, l)
-				} else {
-					log.Debugf("an error occured while getting latency data for resource: %s-%s => %v ", sli.Provider, sli.ID, err)
-					latencyHasErrors = true
+				if sl.Type == "latency" {
+					if l, err := provider.Get99PercentLatencyMetricForResource(sli.ID, from, to); err == nil {
+						//allLatency = append(allLatency, l)
+						allValues = append(allValues, l)
+					} else {
+						log.Debugf("an error occured while getting latency data for resource: %s-%s => %v ", sli.Provider, sli.ID, err)
+						//latencyHasErrors = true
+						valuesHasError = true
+					}
 				}
 
-				if e, err := provider.GetErrorPercentageMetricForResource(sli.ID, from, to); err == nil {
-					allErrorPercentages = append(allErrorPercentages, e)
-				} else {
-	
-					log.Debugf("an error occured while getting error percentage data for SLI: %s-%s => %v ", sli.Provider, sli.ID, err)
-					errorPercentHasErrors = true
+				if sl.Type == "availability" {
+					if e, err := provider.GetErrorPercentageMetricForResource(sli.ID, from, to); err == nil {
+						//allErrorPercentages = append(allErrorPercentages, e)
+						allValues = append(allValues, e)
+					} else {
+
+						log.Debugf("an error occured while getting error percentage data for SLI: %s-%s => %v ", sli.Provider, sli.ID, err)
+						//errorPercentHasErrors = true
+						valuesHasError = true
+					}
 				}
+
 			}
 
-			// define actual indicator data received and errors
-			actual := (&ServiceLevelIndicators{
-				ErrorPercent: average(allErrorPercentages),
-				LatencyMs:    int64(average(allLatency)),
-			}).setErrorState(latencyErr, latencyHasErrors).
-				setErrorState(errPercentErr, errorPercentHasErrors)
+			/*
+				// define actual indicator data received and errors
+				actual := (&ServiceLevelIndicators{
+					ErrorPercent: average(allErrorPercentages),
+					LatencyMs:    int64(average(allLatency)),
+				}).setErrorState(latencyErr, latencyHasErrors).
+					setErrorState(errPercentErr, errorPercentHasErrors)
+			*/
 
-			r.ServiceLevel = &ServiceLevel{
-				Target: &ServiceLevelIndicators{
-					ErrorPercent: sl.Objective,
-					LatencyMs:    sl.Threshold.Milliseconds(),
+			fmt.Println(">>>", sl.Name, sl.Type, allValues, valuesHasError)
+
+			var result *ServiceLevelResult
+			if !valuesHasError {
+
+				// hack for now, until we merge the new API for fetching latency as %
+
+				if sl.Type == "latency" {
+					objective := float64(sl.Threshold.Duration.Milliseconds())
+					avg := average(allValues)
+					delta := avg - objective
+
+					result = &ServiceLevelResult{
+						Objective: objective,
+						Actual:    round2digits(avg),
+						Delta:     round2digits(delta),
+					}
+
+				} else {
+
+					result = &ServiceLevelResult{
+						Objective: sl.Objective,
+						Actual:    round2digits(average(allValues)),
+						Delta:     round2digits(average(allValues) - sl.Objective),
+					}
+				}
+
+			}
+			r.ServiceLevels = append(r.ServiceLevels, &ServiceLevel{
+				Name:    sl.Name,
+				Type:    sl.Type,
+				Result:  result,
+				errored: valuesHasError,
+				ObservationWindow: Window{
+					To:   to,
+					From: from,
 				},
-				Actual: actual,
-				Delta:  &ServiceLevelIndicators{},
-			}
+			})
 
-			r.ServiceLevel.Delta.ErrorPercent = r.ServiceLevel.Actual.ErrorPercent - r.ServiceLevel.Target.ErrorPercent
-			r.ServiceLevel.Delta.LatencyMs = r.ServiceLevel.Actual.LatencyMs - r.ServiceLevel.Target.LatencyMs
+			//r.ServiceLevel.Delta.ErrorPercent = r.ServiceLevel.Actual.ErrorPercent - r.ServiceLevel.Target.ErrorPercent
+			//r.ServiceLevel.Delta.LatencyMs = r.ServiceLevel.Actual.LatencyMs - r.ServiceLevel.Target.LatencyMs
 		}
 
 		if s.Dependencies != nil {

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -25,14 +25,22 @@ var notSuportedErrorBuilder = func(thingType, thingName string) error {
 	return fmt.Errorf("%s type '%s' is not currently supported. I've informed ReliablyHQ about this; check back later - maybe we'll be able to help then.", thingType, thingName)
 }
 
-func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
+func FromManifest(m *manifest.Manifest) (report *Report, err error) {
 	// check for nil manifest
 	if m == nil {
-		return reports, fmt.Errorf("nil manifest.Manifest received")
+		err = go_errors.New("nil manifest.Manifest received")
+		return
 	}
 
 	to := time.Now()
 	from := to.Add(-oneDay)
+
+	var services []*Service = make([]*Service, 0)
+	report = &Report{
+		APIVersion: apiVersion,
+		Timestamp:  timestampFn(),
+		Services:   services,
+	}
 
 	for _, s := range m.Services {
 		if s == nil {
@@ -46,11 +54,12 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 		// Also need to check if there are SLIs in each Service Level
 
 		sls := make([]*ServiceLevel, 0)
-		r := Report{Name: s.Name, ServiceLevels: sls}
-
-		r.APIVersion = apiVersion
-		r.Timestamp = timestampFn()
-		r.Dependencies = []string{}
+		//r := Report{Name: s.Name, ServiceLevels: sls}
+		rs := Service{
+			Name:          s.Name,
+			Dependencies:  []string{},
+			ServiceLevels: sls,
+		}
 
 		//allLatency := []float64{}
 		//allErrorPercentages := []float64{}
@@ -133,7 +142,7 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 				}
 
 			}
-			r.ServiceLevels = append(r.ServiceLevels, &ServiceLevel{
+			rs.ServiceLevels = append(rs.ServiceLevels, &ServiceLevel{
 				Name:    sl.Name,
 				Type:    sl.Type,
 				Result:  result,
@@ -149,10 +158,11 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 		}
 
 		if s.Dependencies != nil {
-			r.Dependencies = s.Dependencies
+			rs.Dependencies = s.Dependencies
 		}
 
-		reports = append(reports, &r)
+		//reports = append(reports, &r)
+		report.Services = append(report.Services, &rs)
 	}
 
 	return

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -124,7 +124,7 @@ func FromManifest(m *manifest.Manifest) (report *Report, err error) {
 				// hack for now, until we merge the new API for fetching latency as %
 
 				if sl.Type == "latency" {
-					objective = float64(sl.Threshold.Duration.Milliseconds())
+					objective = float64(sl.Criteria.(manifest.LatencyCriteria).Threshold.Duration.Milliseconds())
 					avg := average(allValues)
 					delta := avg - objective
 					sloIsMet = avg <= objective

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -31,14 +31,16 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 		return reports, fmt.Errorf("nil manifest.Manifest received")
 	}
 
-	for _, s := range m.ServiceLevel {
+	for _, s := range m.Services {
 		if s == nil {
-			return nil, go_errors.New("I don't know anything about your service objectives. Run `reliably slo init` to tell me.")
+			return nil, go_errors.New("I don't know anything about your services. Run `reliably slo init` to tell me.")
 		}
 
-		if len(s.Resources) == 0 {
-			return nil, go_errors.New("you haven't told us about any resources, so we won't be able to give you a report. Sorry :(")
+		if len(s.ServiceLevels) == 0 {
+			return nil, go_errors.New("you haven't told us about any SLOs, so we won't be able to give you a report. Sorry :(")
 		}
+
+		// Also need to check if there are SLIs in each Service Level
 
 		r := Report{Name: s.Name}
 
@@ -52,51 +54,53 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 		var latencyHasErrors = false
 		var errorPercentHasErrors = false
 
-		for _, resource := range s.Resources {
-			provider, err := getProviderForResource(resource.Provider)
-			if err != nil {
-				return nil, fmt.Errorf("an error occured while getting a provider for resource: %s => %s", resource.Provider, err)
+		for _, sl := range s.ServiceLevels {
+			for _, sli := range sl.Indicators {
+				provider, err := getProviderForResource(sli.Provider)
+				if err != nil {
+					return nil, fmt.Errorf("an error occured while getting a provider for sli: %s => %s", sli.Provider, err)
+				}
+
+				to := time.Now()
+				from := to.Add(-oneDay)
+				r.ObservationWindow.To = to
+				r.ObservationWindow.From = from
+
+				if l, err := provider.Get99PercentLatencyMetricForResource(sli.ID, from, to); err == nil {
+					allLatency = append(allLatency, l)
+				} else {
+					log.Debugf("an error occured while getting latency data for resource: %s-%s => %v ", sli.Provider, sli.ID, err)
+					latencyHasErrors = true
+				}
+
+				if e, err := provider.GetErrorPercentageMetricForResource(sli.ID, from, to); err == nil {
+					allErrorPercentages = append(allErrorPercentages, e)
+				} else {
+	
+					log.Debugf("an error occured while getting error percentage data for SLI: %s-%s => %v ", sli.Provider, sli.ID, err)
+					errorPercentHasErrors = true
+				}
 			}
 
-			to := time.Now()
-			from := to.Add(-oneDay)
-			r.ObservationWindow.To = to
-			r.ObservationWindow.From = from
+			// define actual indicator data received and errors
+			actual := (&ServiceLevelIndicators{
+				ErrorPercent: average(allErrorPercentages),
+				LatencyMs:    int64(average(allLatency)),
+			}).setErrorState(latencyErr, latencyHasErrors).
+				setErrorState(errPercentErr, errorPercentHasErrors)
 
-			if l, err := provider.Get99PercentLatencyMetricForResource(resource.ID, from, to); err == nil {
-				allLatency = append(allLatency, l)
-			} else {
-				log.Debugf("an error occured while getting latency data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
-				latencyHasErrors = true
+			r.ServiceLevel = &ServiceLevel{
+				Target: &ServiceLevelIndicators{
+					ErrorPercent: sl.Objective,
+					LatencyMs:    sl.Threshold.Milliseconds(),
+				},
+				Actual: actual,
+				Delta:  &ServiceLevelIndicators{},
 			}
 
-			if e, err := provider.GetErrorPercentageMetricForResource(resource.ID, from, to); err == nil {
-				allErrorPercentages = append(allErrorPercentages, e)
-			} else {
-
-				log.Debugf("an error occured while getting error percentage data for resource: %s-%s => %v ", resource.Provider, resource.ID, err)
-				errorPercentHasErrors = true
-			}
+			r.ServiceLevel.Delta.ErrorPercent = r.ServiceLevel.Actual.ErrorPercent - r.ServiceLevel.Target.ErrorPercent
+			r.ServiceLevel.Delta.LatencyMs = r.ServiceLevel.Actual.LatencyMs - r.ServiceLevel.Target.LatencyMs
 		}
-
-		// define actual indicator data received and errors
-		actual := (&ServiceLevelIndicators{
-			ErrorPercent: average(allErrorPercentages),
-			LatencyMs:    int64(average(allLatency)),
-		}).setErrorState(latencyErr, latencyHasErrors).
-			setErrorState(errPercentErr, errorPercentHasErrors)
-
-		r.ServiceLevel = &ServiceLevel{
-			Target: &ServiceLevelIndicators{
-				ErrorPercent: s.Objective,
-				LatencyMs:    s.Threshold.Milliseconds(),
-			},
-			Actual: actual,
-			Delta:  &ServiceLevelIndicators{},
-		}
-
-		r.ServiceLevel.Delta.ErrorPercent = r.ServiceLevel.Actual.ErrorPercent - r.ServiceLevel.Target.ErrorPercent
-		r.ServiceLevel.Delta.LatencyMs = r.ServiceLevel.Actual.LatencyMs - r.ServiceLevel.Target.LatencyMs
 
 		if s.Dependencies != nil {
 			r.Dependencies = s.Dependencies

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -116,41 +116,51 @@ func FromManifest(m *manifest.Manifest) (report *Report, err error) {
 
 			//fmt.Println(">>>", sl.Name, sl.Type, allValues, valuesHasError)
 
+			var sloIsMet bool
+			var objective float64 = sl.Objective
 			var result *ServiceLevelResult
 			if !valuesHasError {
 
 				// hack for now, until we merge the new API for fetching latency as %
 
 				if sl.Type == "latency" {
-					objective := float64(sl.Threshold.Duration.Milliseconds())
+					objective = float64(sl.Threshold.Duration.Milliseconds())
 					avg := average(allValues)
 					delta := avg - objective
 
+					sloIsMet = avg < objective
+
 					result = &ServiceLevelResult{
-						Objective: objective,
-						Actual:    round2digits(avg),
-						Delta:     round2digits(delta),
+						//Objective: objective,
+						Actual: round2digits(avg),
+						Delta:  round2digits(delta),
 					}
 
 				} else {
+					avg := average(allValues)
+					delta := avg - objective
+
+					sloIsMet = avg > objective
 
 					result = &ServiceLevelResult{
-						Objective: sl.Objective,
-						Actual:    round2digits(average(allValues)),
-						Delta:     round2digits(average(allValues) - sl.Objective),
+						//Objective: sl.Objective,
+						Actual: avg,
+						Delta:  delta,
 					}
 				}
 
 			}
 			rs.ServiceLevels = append(rs.ServiceLevels, &ServiceLevel{
-				Name:    sl.Name,
-				Type:    sl.Type,
-				Result:  result,
-				errored: valuesHasError,
+				Name:      sl.Name,
+				Type:      sl.Type,
+				Objective: objective,
+				Result:    result,
 				ObservationWindow: Window{
 					To:   to,
 					From: from,
 				},
+				errored:  valuesHasError,
+				sloIsMet: sloIsMet,
 			})
 
 			//r.ServiceLevel.Delta.ErrorPercent = r.ServiceLevel.Actual.ErrorPercent - r.ServiceLevel.Target.ErrorPercent

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -72,7 +72,7 @@ func FromManifest(m *manifest.Manifest) (report *Report, err error) {
 
 		for _, sl := range s.ServiceLevels {
 
-			fmt.Println(sl.Name, sl.Type, sl.Objective, sl.Threshold)
+			//fmt.Println(sl.Name, sl.Type, sl.Objective, sl.Threshold)
 
 			for _, sli := range sl.Indicators {
 				provider, err := getProviderForResource(sli.Provider)
@@ -114,7 +114,7 @@ func FromManifest(m *manifest.Manifest) (report *Report, err error) {
 					setErrorState(errPercentErr, errorPercentHasErrors)
 			*/
 
-			fmt.Println(">>>", sl.Name, sl.Type, allValues, valuesHasError)
+			//fmt.Println(">>>", sl.Name, sl.Type, allValues, valuesHasError)
 
 			var result *ServiceLevelResult
 			if !valuesHasError {

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -127,25 +127,25 @@ func FromManifest(m *manifest.Manifest) (report *Report, err error) {
 					objective = float64(sl.Threshold.Duration.Milliseconds())
 					avg := average(allValues)
 					delta := avg - objective
-
-					sloIsMet = avg < objective
+					sloIsMet = avg <= objective
 
 					result = &ServiceLevelResult{
 						//Objective: objective,
-						Actual: round2digits(avg),
-						Delta:  round2digits(delta),
+						Actual:   round2digits(avg),
+						Delta:    round2digits(delta),
+						sloIsMet: sloIsMet,
 					}
 
 				} else {
 					avg := average(allValues)
 					delta := avg - objective
-
-					sloIsMet = avg > objective
+					sloIsMet = avg >= objective
 
 					result = &ServiceLevelResult{
 						//Objective: sl.Objective,
-						Actual: avg,
-						Delta:  delta,
+						Actual:   avg,
+						Delta:    delta,
+						sloIsMet: sloIsMet,
 					}
 				}
 
@@ -159,8 +159,7 @@ func FromManifest(m *manifest.Manifest) (report *Report, err error) {
 					To:   to,
 					From: from,
 				},
-				errored:  valuesHasError,
-				sloIsMet: sloIsMet,
+				errored: valuesHasError,
 			})
 
 			//r.ServiceLevel.Delta.ErrorPercent = r.ServiceLevel.Actual.ErrorPercent - r.ServiceLevel.Target.ErrorPercent

--- a/core/report/generate.go
+++ b/core/report/generate.go
@@ -88,8 +88,8 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 
 		r.ServiceLevel = &ServiceLevel{
 			Target: &ServiceLevelIndicators{
-				ErrorPercent: s.Objective.ErrorBudgetPercent,
-				LatencyMs:    s.Objective.Latency.Milliseconds(),
+				ErrorPercent: s.Objective,
+				LatencyMs:    s.Threshold.Milliseconds(),
 			},
 			Actual: actual,
 			Delta:  &ServiceLevelIndicators{},
@@ -98,8 +98,8 @@ func FromManifest(m *manifest.Manifest) (reports []*Report, err error) {
 		r.ServiceLevel.Delta.ErrorPercent = r.ServiceLevel.Actual.ErrorPercent - r.ServiceLevel.Target.ErrorPercent
 		r.ServiceLevel.Delta.LatencyMs = r.ServiceLevel.Actual.LatencyMs - r.ServiceLevel.Target.LatencyMs
 
-		if m.Dependencies != nil {
-			r.Dependencies = m.Dependencies
+		if s.Dependencies != nil {
+			r.Dependencies = s.Dependencies
 		}
 
 		reports = append(reports, &r)

--- a/core/report/generate_test.go
+++ b/core/report/generate_test.go
@@ -115,8 +115,8 @@ func TestFromManifest(t *testing.T) {
 									Objective: 99,
 									Indicators: []manifest.ServiceLevelIndicator{
 										{
-											Provider: "aws",
-											ID: "arn2",
+											Provider: "test_from_manifest",
+											ID: "abc13",
 										},
 									},
 								},

--- a/core/report/generate_test.go
+++ b/core/report/generate_test.go
@@ -138,8 +138,9 @@ func TestFromManifest(t *testing.T) {
 								Type:      "latency",
 								Objective: float64(300),
 								Result: &ServiceLevelResult{
-									Actual: float64(p.latencyMetricValue),
-									Delta:  float64(p.latencyMetricValue) - 300,
+									Actual:   float64(p.latencyMetricValue),
+									Delta:    float64(p.latencyMetricValue) - 300,
+									sloIsMet: true,
 								},
 							},
 						},

--- a/core/report/generate_test.go
+++ b/core/report/generate_test.go
@@ -109,14 +109,14 @@ func TestFromManifest(t *testing.T) {
 							Name: "Service A",
 							ServiceLevels: []*manifest.ServiceLevel{
 								&manifest.ServiceLevel{
-									Name: "Service A Latency",
-									Type: "latency",
+									Name:      "Service A Latency",
+									Type:      "latency",
 									Threshold: core.Duration{Duration: 300 * time.Millisecond},
 									Objective: 99,
 									Indicators: []manifest.ServiceLevelIndicator{
 										{
 											Provider: "test_from_manifest",
-											ID: "abc13",
+											ID:       "abc13",
 										},
 									},
 								},
@@ -128,21 +128,23 @@ func TestFromManifest(t *testing.T) {
 			},
 			want: &Report{
 				Timestamp: tVal,
-				ServiceLevel: &ServiceLevel{
-					Target: &ServiceLevelIndicators{
-						ErrorPercent: 99,
-						LatencyMs:    300,
-					},
-					Actual: &ServiceLevelIndicators{
-						ErrorPercent: p.errorPercentValue,
-						LatencyMs:    int64(p.latencyMetricValue),
-					},
-					Delta: &ServiceLevelIndicators{
-						ErrorPercent: p.errorPercentValue - 99,
-						LatencyMs:    int64(p.latencyMetricValue) - 300,
+				Services: []*Service{
+					{
+						Name:         "Service A",
+						Dependencies: []string{"dependencies"},
+						ServiceLevels: []*ServiceLevel{
+							{
+								Name: "Service A Latency",
+								Type: "latency",
+								Result: &ServiceLevelResult{
+									Objective: float64(300),
+									Actual:    float64(p.latencyMetricValue),
+									Delta:     float64(p.latencyMetricValue) - 300,
+								},
+							},
+						},
 					},
 				},
-				Dependencies: []string{"dependencies"},
 			},
 			wantErr: false,
 		},
@@ -167,15 +169,9 @@ func TestFromManifest(t *testing.T) {
 			// else just assert error
 			assert.NoError(t, err)
 
-			assert.Equal(t, got[0].Timestamp, tt.want.Timestamp,
-				"FromManifest().Timestamp = %v, want %v", got[0].Timestamp, tt.want.Timestamp)
-
-			assert.Equal(t, got[0].ServiceLevel, tt.want.ServiceLevel,
-				"FromManifest().ServiceLevel = %v, want %v", got[0].ServiceLevel, tt.want.ServiceLevel)
-
-			assert.Equal(t, got[0].Dependencies, tt.want.Dependencies,
-				"FromManifest().Dependencies = %v, want %v", got[0].Dependencies, tt.want.Dependencies)
-
+			assert.Equal(t, got.Timestamp, tt.want.Timestamp, "Timestamp mismatch")
+			assert.Equal(t, got.Services[0].ServiceLevels[0].Result, tt.want.Services[0].ServiceLevels[0].Result, "service level result mismatch")
+			assert.Equal(t, got.Services[0].Dependencies, tt.want.Services[0].Dependencies, "service dependencies mismatch")
 		})
 	}
 }

--- a/core/report/generate_test.go
+++ b/core/report/generate_test.go
@@ -134,12 +134,12 @@ func TestFromManifest(t *testing.T) {
 						Dependencies: []string{"dependencies"},
 						ServiceLevels: []*ServiceLevel{
 							{
-								Name: "Service A Latency",
-								Type: "latency",
+								Name:      "Service A Latency",
+								Type:      "latency",
+								Objective: float64(300),
 								Result: &ServiceLevelResult{
-									Objective: float64(300),
-									Actual:    float64(p.latencyMetricValue),
-									Delta:     float64(p.latencyMetricValue) - 300,
+									Actual: float64(p.latencyMetricValue),
+									Delta:  float64(p.latencyMetricValue) - 300,
 								},
 							},
 						},

--- a/core/report/generate_test.go
+++ b/core/report/generate_test.go
@@ -109,9 +109,11 @@ func TestFromManifest(t *testing.T) {
 							Name: "Service A",
 							ServiceLevels: []*manifest.ServiceLevel{
 								&manifest.ServiceLevel{
-									Name:      "Service A Latency",
-									Type:      "latency",
-									Threshold: core.Duration{Duration: 300 * time.Millisecond},
+									Name: "Service A Latency",
+									Type: "latency",
+									Criteria: manifest.LatencyCriteria{
+										Threshold: core.Duration{Duration: 300 * time.Millisecond},
+									},
 									Objective: 99,
 									Indicators: []manifest.ServiceLevelIndicator{
 										{

--- a/core/report/generate_test.go
+++ b/core/report/generate_test.go
@@ -77,8 +77,8 @@ func Test_getProviderForResource(t *testing.T) {
 
 func TestFromManifest(t *testing.T) {
 	p := &dummyProvider{
-		latencyMetricValue: 100,
-		errorPercentValue:  1,
+		latencyMetricValue: 250,
+		errorPercentValue:  99,
 	}
 
 	metrics.ProviderFactories["test_from_manifest"] = func() (metrics.Provider, error) { return p, nil }
@@ -99,45 +99,50 @@ func TestFromManifest(t *testing.T) {
 		}
 	)
 
-	srv := &manifest.Service{
-		Objective: manifest.ServiceLevelObjective{
-			Latency:            core.Duration{Duration: time.Millisecond * 250},
-			ErrorBudgetPercent: 2.5,
-		},
-		Resources: []manifest.ServiceResource{
-			{
-				Provider: "test_from_manifest",
-				ID:       "abc13",
-			},
-		},
-	}
-
 	tests := []subtest{
 		{
 			name: "returns report with correct info",
 			args: args{
 				m: &manifest.Manifest{
-					ServiceLevel: []*manifest.Service{srv},
-					Dependencies: []string{"abc"},
+					Services: []*manifest.Service{
+						&manifest.Service{
+							Name: "Service A",
+							ServiceLevels: []*manifest.ServiceLevel{
+								&manifest.ServiceLevel{
+									Name: "Service A Latency",
+									Type: "latency",
+									Threshold: core.Duration{Duration: 300 * time.Millisecond},
+									Objective: 99,
+									Indicators: []manifest.ServiceLevelIndicator{
+										{
+											Provider: "aws",
+											ID: "arn2",
+										},
+									},
+								},
+							},
+							Dependencies: []string{"dependencies"},
+						},
+					},
 				},
 			},
 			want: &Report{
 				Timestamp: tVal,
 				ServiceLevel: &ServiceLevel{
 					Target: &ServiceLevelIndicators{
-						ErrorPercent: 2.5,
-						LatencyMs:    250,
+						ErrorPercent: 99,
+						LatencyMs:    300,
 					},
 					Actual: &ServiceLevelIndicators{
 						ErrorPercent: p.errorPercentValue,
 						LatencyMs:    int64(p.latencyMetricValue),
 					},
 					Delta: &ServiceLevelIndicators{
-						ErrorPercent: p.errorPercentValue - 2.5,
-						LatencyMs:    int64(p.latencyMetricValue) - 250,
+						ErrorPercent: p.errorPercentValue - 99,
+						LatencyMs:    int64(p.latencyMetricValue) - 300,
 					},
 				},
-				Dependencies: []string{"abc"},
+				Dependencies: []string{"dependencies"},
 			},
 			wantErr: false,
 		},

--- a/core/report/math.go
+++ b/core/report/math.go
@@ -1,5 +1,9 @@
 package report
 
+import (
+	"math"
+)
+
 func sum(array []float64) float64 {
 	var f float64 = 0
 
@@ -17,4 +21,8 @@ func average(array []float64) float64 {
 	}
 
 	return sum(array) / float64(l)
+}
+
+func round2digits(f float64) float64 {
+	return math.Round(f*100) / 100
 }

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -34,18 +34,6 @@ type ServiceLevel struct {
 	// used to record whether a particular SLI had
 	// error in it's retrieval process
 	errored bool `json:"-"`
-
-	// used to record whether the SLO is met or not
-	sloIsMet bool `json:"-"`
-}
-
-type ServiceLevelIndicators struct {
-	ErrorPercent   float64 `json:"error_percent"`
-	LatencyPercent int64   `json:"latency_percent"`
-
-	// used to record whether a particular property had
-	// error in it's retrieval process
-	errored bool `json:"-"`
 }
 
 type Window struct {
@@ -54,37 +42,9 @@ type Window struct {
 }
 
 type ServiceLevelResult struct {
-	//Objective interface{} `json:"slo"`
 	Actual interface{} `json:"actual"`
 	Delta  interface{} `json:"delta"`
-}
 
-/*
-func (s *ServiceLevelIndicators) setErrorState(i indicatorErrType, b bool) *ServiceLevelIndicators {
-	s.errored[i] = b
-	return s
+	// used to record whether the SLO is met or not
+	sloIsMet bool `json:"-"`
 }
-
-func (s *ServiceLevelIndicators) hasErrors(i indicatorErrType) bool {
-	return s.errored[i]
-}
-
-func (s *ServiceLevelIndicators) errorPercentString() string {
-	if s.hasErrors(errPercentErr) {
-		return "---"
-	}
-	return fmt.Sprintf("%.2f", s.ErrorPercent)
-}
-
-func (s *ServiceLevelIndicators) latencyMsString() string {
-	if s.hasErrors(latencyErr) {
-		return "---"
-	}
-	return fmt.Sprintf("%dms", s.LatencyMs)
-}
-*/
-// indicatorErrType - used to define indicator error types
-type indicatorErrType int
-
-var latencyErr indicatorErrType = 0
-var errPercentErr indicatorErrType = 1

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -1,20 +1,16 @@
 package report
 
 import (
-	"fmt"
+	//"fmt"
 	"time"
 )
 
 type Report struct {
-	APIVersion   string        `json:"api_version"`
-	Timestamp    time.Time     `json:"timestamp"`
-	Dependencies []string      `json:"dependencies"`
-	ServiceLevel *ServiceLevel `json:"service_level"`
-	Name         string        `json:"name"`
-
-	// TODO: decide whether this should be implemented as
-	// Observation Windor or Boundary
-	ObservationWindow Window `json:"window"`
+	APIVersion    string          `json:"api_version"`
+	Timestamp     time.Time       `json:"timestamp"`
+	Dependencies  []string        `json:"-"`
+	ServiceLevels []*ServiceLevel `json:"service_levels"`
+	Name          string          `json:"name"`
 }
 
 type Window struct {
@@ -23,20 +19,39 @@ type Window struct {
 }
 
 type ServiceLevel struct {
-	Target *ServiceLevelIndicators `json:"target"`
-	Actual *ServiceLevelIndicators `json:"actual"`
-	Delta  *ServiceLevelIndicators `json:"delta"`
+	Name   string              `json:"name"`
+	Type   string              `json:"type"`
+	Result *ServiceLevelResult `json:"result"`
+
+	//Target *ServiceLevelIndicators `json:"target"`
+	//Actual *ServiceLevelIndicators `json:"actual"`
+	//Delta  *ServiceLevelIndicators `json:"delta"`
+
+	// TODO: decide whether this should be implemented as
+	// Observation Windor or Boundary
+	ObservationWindow Window `json:"window"`
+
+	// used to record whether a particular SLI had
+	// error in it's retrieval process
+	errored bool `json:"-"`
 }
 
 type ServiceLevelIndicators struct {
-	ErrorPercent float64 `json:"error_percent"`
-	LatencyMs    int64   `json:"latency_ms"`
+	ErrorPercent   float64 `json:"error_percent"`
+	LatencyPercent int64   `json:"latency_percent"`
 
 	// used to record whether a particular property had
 	// error in it's retrieval process
-	errored [2]bool `json:"-"`
+	errored bool `json:"-"`
 }
 
+type ServiceLevelResult struct {
+	Objective interface{} `json:"slo"`
+	Actual    interface{} `json:"actual"`
+	Delta     interface{} `json:"delta"`
+}
+
+/*
 func (s *ServiceLevelIndicators) setErrorState(i indicatorErrType, b bool) *ServiceLevelIndicators {
 	s.errored[i] = b
 	return s
@@ -59,7 +74,7 @@ func (s *ServiceLevelIndicators) latencyMsString() string {
 	}
 	return fmt.Sprintf("%dms", s.LatencyMs)
 }
-
+*/
 // indicatorErrType - used to define indicator error types
 type indicatorErrType int
 

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -18,9 +18,10 @@ type Service struct {
 }
 
 type ServiceLevel struct {
-	Name   string              `json:"name"`
-	Type   string              `json:"type"`
-	Result *ServiceLevelResult `json:"result"`
+	Name      string              `json:"name"`
+	Type      string              `json:"type"`
+	Objective float64             `json:"objective"`
+	Result    *ServiceLevelResult `json:"result"`
 
 	//Target *ServiceLevelIndicators `json:"target"`
 	//Actual *ServiceLevelIndicators `json:"actual"`
@@ -33,6 +34,9 @@ type ServiceLevel struct {
 	// used to record whether a particular SLI had
 	// error in it's retrieval process
 	errored bool `json:"-"`
+
+	// used to record whether the SLO is met or not
+	sloIsMet bool `json:"-"`
 }
 
 type ServiceLevelIndicators struct {
@@ -50,9 +54,9 @@ type Window struct {
 }
 
 type ServiceLevelResult struct {
-	Objective interface{} `json:"slo"`
-	Actual    interface{} `json:"actual"`
-	Delta     interface{} `json:"delta"`
+	//Objective interface{} `json:"slo"`
+	Actual interface{} `json:"actual"`
+	Delta  interface{} `json:"delta"`
 }
 
 /*

--- a/core/report/report.go
+++ b/core/report/report.go
@@ -6,16 +6,15 @@ import (
 )
 
 type Report struct {
-	APIVersion    string          `json:"api_version"`
-	Timestamp     time.Time       `json:"timestamp"`
+	APIVersion string     `json:"api_version"`
+	Timestamp  time.Time  `json:"timestamp"`
+	Services   []*Service `json:"services"`
+}
+
+type Service struct {
 	Dependencies  []string        `json:"-"`
 	ServiceLevels []*ServiceLevel `json:"service_levels"`
 	Name          string          `json:"name"`
-}
-
-type Window struct {
-	From time.Time `json:"from"`
-	To   time.Time `json:"to"`
 }
 
 type ServiceLevel struct {
@@ -43,6 +42,11 @@ type ServiceLevelIndicators struct {
 	// used to record whether a particular property had
 	// error in it's retrieval process
 	errored bool `json:"-"`
+}
+
+type Window struct {
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
 }
 
 type ServiceLevelResult struct {

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -59,13 +59,12 @@ func Write(format Format, r *Report, w io.Writer, l *logrus.Logger) {
 		tabbedoutput(r, w)
 	}
 
-	return
 }
 
 func reportSimpleText(r *Report, w io.Writer) {
 
 	for i, svc := range r.Services {
-		fmt.Fprintf(w, color.Yellow(fmt.Sprintf("Service #%d: %s\n", i+1, svc.Name)))
+		fmt.Fprint(w, color.Yellow(fmt.Sprintf("Service #%d: %s\n", i+1, svc.Name)))
 
 		for _, sl := range svc.ServiceLevels {
 
@@ -80,16 +79,11 @@ func reportSimpleText(r *Report, w io.Writer) {
 				unit := "%"
 
 				if sl.Type == "latency" {
-
-					if float64(sl.Result.Actual.(float64)) > sl.Objective {
-						tick = iostreams.FailureIcon()
-					}
 					unit = "ms"
+				}
 
-				} else {
-					if float64(sl.Result.Actual.(float64)) < sl.Objective {
-						tick = iostreams.FailureIcon()
-					}
+				if !sl.Result.sloIsMet {
+					tick = iostreams.FailureIcon()
 				}
 
 				fmt.Fprintf(w, "%s %s: %v%s (last %s) [objective: %v%s, delta: %v%s]\n",
@@ -100,7 +94,6 @@ func reportSimpleText(r *Report, w io.Writer) {
 					sl.Result.Delta, unit)
 
 			}
-
 		}
 
 		if i < len(r.Services)-1 {
@@ -164,7 +157,7 @@ func tabbedoutput(r *Report, w io.Writer) {
 
 			} else {
 
-				if !sl.sloIsMet {
+				if !sl.Result.sloIsMet {
 					tick = iconEx
 					colorFunc = color.Red
 				}
@@ -177,7 +170,6 @@ func tabbedoutput(r *Report, w io.Writer) {
 				table.Append(row)
 
 			}
-
 		}
 
 		if i < len(r.Services)-1 {
@@ -185,65 +177,6 @@ func tabbedoutput(r *Report, w io.Writer) {
 		}
 
 	}
-
-	/*
-		var actual string
-		var delta = func(actual, s string) string {
-			if actual != "---" {
-				return s
-			}
-			return actual
-		}
-	*/
-
-	/*
-		// set error budget data
-		actual = r.ServiceLevel.Actual.errorPercentString()
-		if r.ServiceLevel.Delta.ErrorPercent > threshold {
-			data = append(data, []string{
-				fmt.Sprintf("%s Error Rate", iconEx),
-				color.Bold(color.IfTrueRed(actual != "---", actual)),
-				fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-				delta(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
-			})
-		} else {
-			data = append(data, []string{
-				fmt.Sprintf("%s Error Rate", iconTick),
-				color.Bold(color.IfTrueGreen(actual != "---", actual)),
-				fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-				delta(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
-			})
-		}
-	*/
-
-	/*
-		// set latency
-		actual = r.ServiceLevel.Actual.latencyMsString()
-		if r.ServiceLevel.Delta.LatencyMs > threshold {
-			data = append(data, []string{
-				fmt.Sprintf("%s Latency", iconEx),
-				color.Bold(color.IfTrueRed(actual != "---", actual)),
-				fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-				delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			})
-		} else {
-			data = append(data, []string{
-				fmt.Sprintf("%s Latency", iconTick),
-				color.Bold(color.IfTrueGreen(actual != "---", actual)),
-				fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-				delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-			})
-		}
-	*/
-
-	/*
-		for _, row := range data {
-			table.Append(fmt.Sprintf("# %s", sl.Name), "", "", "")
-			table.Append(row)
-			// add black row for spacing betwen services
-			table.Append([]string{"", "", "", ""})
-		}
-	*/
 
 	// render table
 	table.Render()

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -86,11 +86,14 @@ func reportSimpleText(r *Report, w io.Writer) {
 
 			} else {
 
+				unit := "%"
+
 				if sl.Type == "latency" {
 
 					if float64(sl.Result.Actual.(float64)) > float64(sl.Result.Objective.(float64)) {
 						tick = iostreams.FailureIcon()
 					}
+					unit = "ms"
 
 				} else {
 					if float64(sl.Result.Actual.(float64)) < float64(sl.Result.Objective.(float64)) {
@@ -98,10 +101,10 @@ func reportSimpleText(r *Report, w io.Writer) {
 					}
 				}
 
-				fmt.Fprintf(w, "%s %s: %v (last %s) [objective: %v, delta: %v]\n",
-					tick, sl.Name, sl.Result.Actual,
+				fmt.Fprintf(w, "%s %s: %v%s (last %s) [objective: %v%s, delta: %v%s]\n",
+					tick, sl.Name, sl.Result.Actual, unit,
 					sl.ObservationWindow.To.Sub(sl.ObservationWindow.From),
-					sl.Result.Objective, sl.Result.Delta)
+					sl.Result.Objective, unit, sl.Result.Delta, unit)
 
 			}
 

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -134,8 +134,13 @@ func tabbedoutput(r *Report, w io.Writer) {
 	emptyRow := []string{"", "", "", ""}
 
 	for i, svc := range r.Services {
-		svcRowHeader := []string{color.Yellow(fmt.Sprintf("Service #%d: %s", i+1, svc.Name))}
+		svcRowHeader := []string{fmt.Sprintf("Service #%d: %s", i+1, svc.Name)}
 		table.Append(svcRowHeader)
+
+		// Using color breaks autowrap text to have weird behavior with unnecessary line return
+		//svcRowHeader = []string{
+		//  color.Yellow(fmt.Sprintf("Service #%d: %s", i+1, svc.Name))}
+		//table.Append(svcRowHeader)
 
 		for _, sl := range svc.ServiceLevels {
 

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+/*
 const (
 	threshold                       = 0
 	lessThan95pcAvailabilityMessage = "An availability of less than 95% allows more than 36.5 hours of downtime per month, which should be possible for any well built app deployed as a single instance. This availability target is probably not high enough for a production-ready system."
@@ -20,6 +21,7 @@ const (
 	latencyExceeded                 = "The average latency threshold has been exceeeded by %vms."
 	latencyValid                    = "The average latency threshold has not been exceeded."
 )
+*/
 
 const (
 	iconTick    = "✅"

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"io"
 
-	consolesize "github.com/nathan-fiscaletti/consolesize-go"
-	"github.com/olekukonko/tablewriter"
-	"github.com/reliablyhq/cli/core/color"
-	"github.com/reliablyhq/cli/core/iostreams"
+	//consolesize "github.com/nathan-fiscaletti/consolesize-go"
+	//"github.com/olekukonko/tablewriter"
+	//"github.com/reliablyhq/cli/core/color"
+	//"github.com/reliablyhq/cli/core/iostreams"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,45 +46,55 @@ func Write(format Format, r *Report, w io.Writer, l *logrus.Logger) {
 		return
 	}
 
-	if r.ServiceLevel.Delta == nil {
-		l.Error("the report does not include a 'Delta'")
-		return
-	}
+	/*
+		if r.ServiceLevel.Delta == nil {
+			l.Error("the report does not include a 'Delta'")
+			return
+		}
+	*/
 
 	switch format {
 	case JSON:
-		if !r.ServiceLevel.Actual.hasErrors(errPercentErr) && !r.ServiceLevel.Actual.hasErrors(latencyErr) {
-			b, _ := json.MarshalIndent(r, "", "  ")
-			fmt.Fprintln(w, string(b))
-		}
-
-	case SimpleText:
-		fmt.Printf("SLO report: (last %s)\n", r.ObservationWindow.To.Sub(r.ObservationWindow.From))
-		if !r.ServiceLevel.Actual.hasErrors(errPercentErr) {
-			if r.ServiceLevel.Delta.ErrorPercent > threshold {
-				msg := fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)
-				fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
-			} else {
-				msg := fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)
-				fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
+		b, _ := json.MarshalIndent(r, "", "  ")
+		fmt.Fprintln(w, string(b))
+		/*
+			if !r.ServiceLevel.Actual.hasErrors(errPercentErr) && !r.ServiceLevel.Actual.hasErrors(latencyErr) {
+				b, _ := json.MarshalIndent(r, "", "  ")
+				fmt.Fprintln(w, string(b))
 			}
-		}
+		*/
 
-		if !r.ServiceLevel.Actual.hasErrors(latencyErr) {
-			if r.ServiceLevel.Delta.LatencyMs > threshold {
-				msg := fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)
-				fmt.Printf("%s Latency: %vms. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.LatencyMs, msg)
-			} else {
-				fmt.Printf("%s Latency: %vms. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.LatencyMs, latencyValid)
-			}
-		}
+		/*
+			case SimpleText:
+				fmt.Printf("SLO report: (last %s)\n", r.ObservationWindow.To.Sub(r.ObservationWindow.From))
+				if !r.ServiceLevel.Actual.hasErrors(errPercentErr) {
+					if r.ServiceLevel.Delta.ErrorPercent > threshold {
+						msg := fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)
+						fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
+					} else {
+						msg := fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)
+						fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
+					}
+				}
 
-	default:
-		tabbedoutput(r, w)
+				if !r.ServiceLevel.Actual.hasErrors(latencyErr) {
+					if r.ServiceLevel.Delta.LatencyMs > threshold {
+						msg := fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)
+						fmt.Printf("%s Latency: %vms. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.LatencyMs, msg)
+					} else {
+						fmt.Printf("%s Latency: %vms. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.LatencyMs, latencyValid)
+					}
+				}
+
+			default:
+				tabbedoutput(r, w)
+		*/
 	}
+
 	return
 }
 
+/*
 func tabbedoutput(r *Report, w io.Writer) {
 	fmt.Fprintf(w, "\n-----------\n[%s] SLO report: (last %s) \n-----------\n",
 		color.Cyan(r.Name),
@@ -168,3 +178,4 @@ func tabbedoutput(r *Report, w io.Writer) {
 	// render table
 	table.Render()
 }
+*/

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -139,8 +139,7 @@ func tabbedoutput(r *Report, w io.Writer) {
 	emptyRow := []string{"", "", "", ""}
 
 	for i, svc := range r.Services {
-		fmt.Println("service name is ", svc.Name)
-		svcRowHeader := []string{color.Yellow(fmt.Sprintf("Service #%d: %s", i+1, svc.Name)), " ", " ", " "}
+		svcRowHeader := []string{color.Yellow(fmt.Sprintf("Service #%d: %s", i+1, svc.Name))}
 		table.Append(svcRowHeader)
 
 		for _, sl := range svc.ServiceLevels {

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 
-	//consolesize "github.com/nathan-fiscaletti/consolesize-go"
-	//"github.com/olekukonko/tablewriter"
-	//"github.com/reliablyhq/cli/core/color"
+	consolesize "github.com/nathan-fiscaletti/consolesize-go"
+	"github.com/olekukonko/tablewriter"
+	"github.com/reliablyhq/cli/core/color"
 	"github.com/reliablyhq/cli/core/iostreams"
 	"github.com/sirupsen/logrus"
 )
@@ -22,8 +22,9 @@ const (
 )
 
 const (
-	iconTick = "✅"
-	iconEx   = "❌"
+	iconTick    = "✅"
+	iconEx      = "❌"
+	iconUnknown = "❔"
 )
 
 // Format - type used to set supported report formats
@@ -55,9 +56,7 @@ func Write(format Format, r *Report, w io.Writer, l *logrus.Logger) {
 		reportSimpleText(r, w)
 
 	default:
-		return
-		//tabbedoutput(r, w)
-
+		tabbedoutput(r, w)
 	}
 
 	return
@@ -66,19 +65,11 @@ func Write(format Format, r *Report, w io.Writer, l *logrus.Logger) {
 func reportSimpleText(r *Report, w io.Writer) {
 
 	for i, svc := range r.Services {
-		fmt.Fprintf(w, "# Service: %s\n", svc.Name)
+		fmt.Fprintf(w, color.Yellow(fmt.Sprintf("Service #%d: %s\n", i+1, svc.Name)))
 
 		for _, sl := range svc.ServiceLevels {
 
 			tick := iostreams.SuccessIcon()
-
-			/*
-				if sl.Type == "latency" {
-
-				} else {
-
-				}
-			*/
 
 			if sl.Result == nil {
 				tick = iostreams.UnknownIcon()
@@ -90,21 +81,23 @@ func reportSimpleText(r *Report, w io.Writer) {
 
 				if sl.Type == "latency" {
 
-					if float64(sl.Result.Actual.(float64)) > float64(sl.Result.Objective.(float64)) {
+					if float64(sl.Result.Actual.(float64)) > sl.Objective {
 						tick = iostreams.FailureIcon()
 					}
 					unit = "ms"
 
 				} else {
-					if float64(sl.Result.Actual.(float64)) < float64(sl.Result.Objective.(float64)) {
+					if float64(sl.Result.Actual.(float64)) < sl.Objective {
 						tick = iostreams.FailureIcon()
 					}
 				}
 
 				fmt.Fprintf(w, "%s %s: %v%s (last %s) [objective: %v%s, delta: %v%s]\n",
-					tick, sl.Name, sl.Result.Actual, unit,
+					tick, sl.Name,
+					sl.Result.Actual, unit,
 					sl.ObservationWindow.To.Sub(sl.ObservationWindow.From),
-					sl.Result.Objective, unit, sl.Result.Delta, unit)
+					sl.Objective, unit,
+					sl.Result.Delta, unit)
 
 			}
 
@@ -115,37 +108,9 @@ func reportSimpleText(r *Report, w io.Writer) {
 		}
 
 	}
-
-	/*
-		fmt.Printf("SLO report: (last %s)\n", r.ObservationWindow.To.Sub(r.ObservationWindow.From))
-		if !r.ServiceLevel.Actual.hasErrors(errPercentErr) {
-			if r.ServiceLevel.Delta.ErrorPercent > threshold {
-				msg := fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)
-				fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
-			} else {
-				msg := fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)
-				fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
-			}
-		}
-
-		if !r.ServiceLevel.Actual.hasErrors(latencyErr) {
-			if r.ServiceLevel.Delta.LatencyMs > threshold {
-				msg := fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)
-				fmt.Printf("%s Latency: %vms. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.LatencyMs, msg)
-			} else {
-				fmt.Printf("%s Latency: %vms. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.LatencyMs, latencyValid)
-			}
-		}
-
-	*/
-
 }
 
-/*
 func tabbedoutput(r *Report, w io.Writer) {
-	fmt.Fprintf(w, "\n-----------\n[%s] SLO report: (last %s) \n-----------\n",
-		color.Cyan(r.Name),
-		r.ObservationWindow.To.Sub(r.ObservationWindow.From))
 
 	cols, _ := consolesize.GetConsoleSize()
 
@@ -161,7 +126,7 @@ func tabbedoutput(r *Report, w io.Writer) {
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetBorder(false)
 	table.SetRowLine(false)
-	// table.SetRowSeparator("--")
+	table.SetRowSeparator("")
 	table.SetColumnSeparator("")
 	table.SetHeaderLine(false)
 	table.SetColWidth(maxColWidth)
@@ -171,58 +136,116 @@ func tabbedoutput(r *Report, w io.Writer) {
 		color.Bold(color.Magenta("Target")),
 		color.Bold(color.Magenta("Delta")), ""})
 
-	var data [][]string
-	var actual string
-	var delta = func(actual, s string) string {
-		if actual != "---" {
-			return s
+	emptyRow := []string{"", "", "", ""}
+
+	for i, svc := range r.Services {
+		fmt.Println("service name is ", svc.Name)
+		svcRowHeader := []string{color.Yellow(fmt.Sprintf("Service #%d: %s", i+1, svc.Name)), " ", " ", " "}
+		table.Append(svcRowHeader)
+
+		for _, sl := range svc.ServiceLevels {
+
+			tick := iconTick
+			unit := "%"
+			colorFunc := color.Green
+
+			if sl.Type == "latency" {
+				unit = "ms"
+			}
+
+			if sl.Result == nil {
+				tick = iconUnknown
+
+				row := []string{
+					fmt.Sprintf("%s %s", tick, sl.Name),
+					"---",
+					fmt.Sprintf("%v%s", sl.Objective, unit),
+					"---"}
+				table.Append(row)
+
+			} else {
+
+				if !sl.sloIsMet {
+					tick = iconEx
+					colorFunc = color.Red
+				}
+
+				row := []string{
+					fmt.Sprintf("%s %s", tick, sl.Name),
+					color.Bold(colorFunc(fmt.Sprintf("%v%s", sl.Result.Actual, unit))),
+					fmt.Sprintf("%v%s", sl.Objective, unit),
+					fmt.Sprintf("%v%s", sl.Result.Delta, unit)}
+				table.Append(row)
+
+			}
+
 		}
-		return actual
+
+		if i < len(r.Services)-1 {
+			table.Append(emptyRow) // empty lines between services except last one
+		}
+
 	}
 
-	// set error budget data
-	actual = r.ServiceLevel.Actual.errorPercentString()
-	if r.ServiceLevel.Delta.ErrorPercent > threshold {
-		data = append(data, []string{
-			fmt.Sprintf("%s Error Rate", iconEx),
-			color.Bold(color.IfTrueRed(actual != "---", actual)),
-			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-			delta(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
-		})
-	} else {
-		data = append(data, []string{
-			fmt.Sprintf("%s Error Rate", iconTick),
-			color.Bold(color.IfTrueGreen(actual != "---", actual)),
-			fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
-			delta(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
-		})
-	}
+	/*
+		var actual string
+		var delta = func(actual, s string) string {
+			if actual != "---" {
+				return s
+			}
+			return actual
+		}
+	*/
 
-	// set latency
-	actual = r.ServiceLevel.Actual.latencyMsString()
-	if r.ServiceLevel.Delta.LatencyMs > threshold {
-		data = append(data, []string{
-			fmt.Sprintf("%s Latency", iconEx),
-			color.Bold(color.IfTrueRed(actual != "---", actual)),
-			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-		})
-	} else {
-		data = append(data, []string{
-			fmt.Sprintf("%s Latency", iconTick),
-			color.Bold(color.IfTrueGreen(actual != "---", actual)),
-			fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
-			delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
-		})
-	}
+	/*
+		// set error budget data
+		actual = r.ServiceLevel.Actual.errorPercentString()
+		if r.ServiceLevel.Delta.ErrorPercent > threshold {
+			data = append(data, []string{
+				fmt.Sprintf("%s Error Rate", iconEx),
+				color.Bold(color.IfTrueRed(actual != "---", actual)),
+				fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
+				delta(actual, fmt.Sprintf("%.2f%%", r.ServiceLevel.Delta.ErrorPercent)),
+			})
+		} else {
+			data = append(data, []string{
+				fmt.Sprintf("%s Error Rate", iconTick),
+				color.Bold(color.IfTrueGreen(actual != "---", actual)),
+				fmt.Sprintf("%.2f", r.ServiceLevel.Target.ErrorPercent),
+				delta(actual, fmt.Sprintf("%.2f%%", -r.ServiceLevel.Delta.ErrorPercent)),
+			})
+		}
+	*/
 
-	for _, row := range data {
-		table.Append(row)
-		// add black row for spacing
-		table.Append([]string{"", "", "", ""})
-	}
+	/*
+		// set latency
+		actual = r.ServiceLevel.Actual.latencyMsString()
+		if r.ServiceLevel.Delta.LatencyMs > threshold {
+			data = append(data, []string{
+				fmt.Sprintf("%s Latency", iconEx),
+				color.Bold(color.IfTrueRed(actual != "---", actual)),
+				fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
+				delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
+			})
+		} else {
+			data = append(data, []string{
+				fmt.Sprintf("%s Latency", iconTick),
+				color.Bold(color.IfTrueGreen(actual != "---", actual)),
+				fmt.Sprintf("%dms", r.ServiceLevel.Target.LatencyMs),
+				delta(actual, fmt.Sprintf("%dms", r.ServiceLevel.Delta.LatencyMs)),
+			})
+		}
+	*/
+
+	/*
+		for _, row := range data {
+			table.Append(fmt.Sprintf("# %s", sl.Name), "", "", "")
+			table.Append(row)
+			// add black row for spacing betwen services
+			table.Append([]string{"", "", "", ""})
+		}
+	*/
 
 	// render table
 	table.Render()
 }
-*/

--- a/core/report/writer.go
+++ b/core/report/writer.go
@@ -8,7 +8,7 @@ import (
 	//consolesize "github.com/nathan-fiscaletti/consolesize-go"
 	//"github.com/olekukonko/tablewriter"
 	//"github.com/reliablyhq/cli/core/color"
-	//"github.com/reliablyhq/cli/core/iostreams"
+	"github.com/reliablyhq/cli/core/iostreams"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,52 +46,96 @@ func Write(format Format, r *Report, w io.Writer, l *logrus.Logger) {
 		return
 	}
 
-	/*
-		if r.ServiceLevel.Delta == nil {
-			l.Error("the report does not include a 'Delta'")
-			return
-		}
-	*/
-
 	switch format {
 	case JSON:
 		b, _ := json.MarshalIndent(r, "", "  ")
 		fmt.Fprintln(w, string(b))
-		/*
-			if !r.ServiceLevel.Actual.hasErrors(errPercentErr) && !r.ServiceLevel.Actual.hasErrors(latencyErr) {
-				b, _ := json.MarshalIndent(r, "", "  ")
-				fmt.Fprintln(w, string(b))
-			}
-		*/
 
-		/*
-			case SimpleText:
-				fmt.Printf("SLO report: (last %s)\n", r.ObservationWindow.To.Sub(r.ObservationWindow.From))
-				if !r.ServiceLevel.Actual.hasErrors(errPercentErr) {
-					if r.ServiceLevel.Delta.ErrorPercent > threshold {
-						msg := fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)
-						fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
-					} else {
-						msg := fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)
-						fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
-					}
-				}
+	case SimpleText:
+		reportSimpleText(r, w)
 
-				if !r.ServiceLevel.Actual.hasErrors(latencyErr) {
-					if r.ServiceLevel.Delta.LatencyMs > threshold {
-						msg := fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)
-						fmt.Printf("%s Latency: %vms. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.LatencyMs, msg)
-					} else {
-						fmt.Printf("%s Latency: %vms. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.LatencyMs, latencyValid)
-					}
-				}
+	default:
+		return
+		//tabbedoutput(r, w)
 
-			default:
-				tabbedoutput(r, w)
-		*/
 	}
 
 	return
+}
+
+func reportSimpleText(r *Report, w io.Writer) {
+
+	for i, svc := range r.Services {
+		fmt.Fprintf(w, "# Service: %s\n", svc.Name)
+
+		for _, sl := range svc.ServiceLevels {
+
+			tick := iostreams.SuccessIcon()
+
+			/*
+				if sl.Type == "latency" {
+
+				} else {
+
+				}
+			*/
+
+			if sl.Result == nil {
+				tick = iostreams.UnknownIcon()
+				fmt.Fprintf(w, "%s %s\n", tick, sl.Name)
+
+			} else {
+
+				if sl.Type == "latency" {
+
+					if float64(sl.Result.Actual.(float64)) > float64(sl.Result.Objective.(float64)) {
+						tick = iostreams.FailureIcon()
+					}
+
+				} else {
+					if float64(sl.Result.Actual.(float64)) < float64(sl.Result.Objective.(float64)) {
+						tick = iostreams.FailureIcon()
+					}
+				}
+
+				fmt.Fprintf(w, "%s %s: %v (last %s) [objective: %v, delta: %v]\n",
+					tick, sl.Name, sl.Result.Actual,
+					sl.ObservationWindow.To.Sub(sl.ObservationWindow.From),
+					sl.Result.Objective, sl.Result.Delta)
+
+			}
+
+		}
+
+		if i < len(r.Services)-1 {
+			fmt.Println() // empty lines between services except last one
+		}
+
+	}
+
+	/*
+		fmt.Printf("SLO report: (last %s)\n", r.ObservationWindow.To.Sub(r.ObservationWindow.From))
+		if !r.ServiceLevel.Actual.hasErrors(errPercentErr) {
+			if r.ServiceLevel.Delta.ErrorPercent > threshold {
+				msg := fmt.Sprintf(errorBudgetExceededf, r.ServiceLevel.Delta.ErrorPercent)
+				fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
+			} else {
+				msg := fmt.Sprintf(errorBudgetTooLowf, -r.ServiceLevel.Delta.ErrorPercent)
+				fmt.Printf("%s Error Rate: %.2f%%. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.ErrorPercent, msg)
+			}
+		}
+
+		if !r.ServiceLevel.Actual.hasErrors(latencyErr) {
+			if r.ServiceLevel.Delta.LatencyMs > threshold {
+				msg := fmt.Sprintf(latencyExceeded, r.ServiceLevel.Delta.LatencyMs)
+				fmt.Printf("%s Latency: %vms. %s\n", iostreams.FailureIcon(), r.ServiceLevel.Actual.LatencyMs, msg)
+			} else {
+				fmt.Printf("%s Latency: %vms. %s\n", iostreams.SuccessIcon(), r.ServiceLevel.Actual.LatencyMs, latencyValid)
+			}
+		}
+
+	*/
+
 }
 
 /*

--- a/tests/reliably.json
+++ b/tests/reliably.json
@@ -1,5 +1,5 @@
 {
-  "service": [
+  "services": [
     {
       "name": "Service A",
       "service-levels": [
@@ -9,11 +9,11 @@
           "slo": 99,
           "sli": [
             {
-              "id": "arn:partition:service:region:account-id:resource-type:resource-id",
+              "id": "arn1",
               "provider": "aws"
             },
             {
-              "id": "project-XXXXXX/google-cloud-load-balancers/resource-A",
+              "id": "uri",
               "provider": "gcp"
             }
           ]
@@ -25,7 +25,7 @@
           "slo": 99,
           "sli": [
             {
-              "id": "arnA",
+              "id": "arn2",
               "provider": "aws"
             }
           ]
@@ -42,7 +42,7 @@
           "slo": 99,
           "sli": [
             {
-              "id": "arn:partition:service:region:account-id:resource-type:resource-id",
+              "id": "arn3",
               "provider": "aws"
             }
           ]

--- a/tests/reliably.json
+++ b/tests/reliably.json
@@ -21,7 +21,9 @@
         {
           "name": "Service A Latency",
           "type": "latency",
-          "threshold": "300ms",
+          "criteria": {
+            "threshold": "300ms"
+          },
           "slo": 99,
           "sli": [
             {

--- a/tests/reliably.json
+++ b/tests/reliably.json
@@ -1,32 +1,54 @@
 {
-  "app": {
-    "name": "unit test app",
-    "owner": "unit test owner",
-    "repo": "github.com/reliablyhq/cli"
-  },
-  "slo": [{
-    "name": "test",
-    "objective": {
-      "latency": "100ms",
-      "error_budget_percent": 0.5
+  "service": [
+    {
+      "name": "Service A",
+      "service-levels": [
+        {
+          "name": "Service A Availability",
+          "type": "availability",
+          "slo": 99,
+          "sli": [
+            {
+              "id": "arn:partition:service:region:account-id:resource-type:resource-id",
+              "provider": "aws"
+            },
+            {
+              "id": "project-XXXXXX/google-cloud-load-balancers/resource-A",
+              "provider": "gcp"
+            }
+          ]
+        },
+        {
+          "name": "Service A Latency",
+          "type": "latency",
+          "threshold": "300ms",
+          "slo": 99,
+          "sli": [
+            {
+              "id": "arnA",
+              "provider": "aws"
+            }
+          ]
+        }
+      ],
+      "dependencies": []
     },
-    "resources": [
-      {
-        "provider": "abc",
-        "id": "123"
-      },
-      {
-        "provider": "xyz",
-        "id": "456"
-      }
-    ]
-  }],
-  "dependencies": [
-    "some service",
-    "some other service"
-  ],
-  "tags": {
-    "team": "abc",
-    "domain": "xyz"
-  }
+    {
+      "name": "Service B",
+      "service-levels": [
+        {
+          "name": "Service B Availability",
+          "type": "availability",
+          "slo": 99,
+          "sli": [
+            {
+              "id": "arn:partition:service:region:account-id:resource-type:resource-id",
+              "provider": "aws"
+            }
+          ]
+        }
+      ],
+      "dependencies": []
+    }
+  ]
 }

--- a/tests/reliably.yaml
+++ b/tests/reliably.yaml
@@ -1,20 +1,20 @@
-service:
+services:
 - name: Service A
   service-levels:
   - name: Service A Availability
     type: availability
     slo: 99
     sli:
-    - id: arn:partition:service:region:account-id:resource-type:resource-id
+    - id: arn1
       provider: aws
-    - id: project-XXXXXX/google-cloud-load-balancers/resource-A
+    - id: uri
       provider: gcp
   - name: Service A Latency
     type: latency
     threshold: 300ms
     slo: 99
     sli:
-    - id: arnA
+    - id: arn2
       provider: aws
   dependencies: []
 - name: Service B
@@ -23,6 +23,6 @@ service:
     type: availability
     slo: 99
     sli:
-    - id: arn:partition:service:region:account-id:resource-type:resource-id
+    - id: arn3
       provider: aws
   dependencies: []

--- a/tests/reliably.yaml
+++ b/tests/reliably.yaml
@@ -11,7 +11,8 @@ services:
       provider: gcp
   - name: Service A Latency
     type: latency
-    threshold: 300ms
+    criteria:
+      threshold: 300ms
     slo: 99
     sli:
     - id: arn2

--- a/tests/reliably.yaml
+++ b/tests/reliably.yaml
@@ -1,22 +1,28 @@
-app: 
-  name: unit test app
-  owner: unit test owner
-  repo: github.com/reliablyhq/cli
-  
-slo:
-  - name:
-    objective:
-      latency: 100ms
-      error_budget_percent: 0.5
-    resources:
-    - provider: abc
-      id: 123
-    - provider: xyz
-      id: 456
-
-dependencies:
-- some service
-- some other service
-tags:
-  team: abc
-  domain: xyz
+service:
+- name: Service A
+  service-levels:
+  - name: Service A Availability
+    type: availability
+    slo: 99
+    sli:
+    - id: arn:partition:service:region:account-id:resource-type:resource-id
+      provider: aws
+    - id: project-XXXXXX/google-cloud-load-balancers/resource-A
+      provider: gcp
+  - name: Service A Latency
+    type: latency
+    threshold: 300ms
+    slo: 99
+    sli:
+    - id: arnA
+      provider: aws
+  dependencies: []
+- name: Service B
+  service-levels:
+  - name: Service B Availability
+    type: availability
+    slo: 99
+    sli:
+    - id: arn:partition:service:region:account-id:resource-type:resource-id
+      provider: aws
+  dependencies: []


### PR DESCRIPTION
This updates the manifest format according to [this strawman](https://github.com/reliablyhq/cli/issues/176#issuecomment-818574506) from issue #176.

The questions asked during `slo init` are also updated to fit this new manifest format (cf #185).

⚠️  **This will clearly break the `slo report` command.**
