### PR TITLE
Add watch flag to SLO report command

### DIFF
--- a/cmd/reliably/slo/report/cmd.go
+++ b/cmd/reliably/slo/report/cmd.go
@@ -157,10 +157,6 @@ func watch(manifestPath string) {
 				report.Write(report.TABBED, r, os.Stdout, log.StandardLogger())
 			}
 
-			// hide cursor
-			if runtime.GOOS != "" {
-				fmt.Print("\033[?25l")
-			}
 		case <-done:
 			return
 		}

--- a/cmd/reliably/slo/report/cmd.go
+++ b/cmd/reliably/slo/report/cmd.go
@@ -31,7 +31,7 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "report",
 		Short: "Report my slo metrics",
-		Run:   run,
+		RunE:  runE,
 	}
 
 	cmd.Flags().StringVarP(&manifestPath, "manifest", "m", manifest.DefaultManifestPath, "the location of the manifest file")
@@ -42,12 +42,11 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func run(_ *cobra.Command, _ []string) {
+func runE(_ *cobra.Command, _ []string) error {
 
 	// check for -w/--watch
 	if watchFlag {
-		watch(manifestPath)
-		return
+		return watch(manifestPath)
 	}
 
 	m, err := manifest.Load(manifestPath)
@@ -55,16 +54,15 @@ func run(_ *cobra.Command, _ []string) {
 		log.Debug(err)
 
 		if os.IsNotExist(err) {
-			log.Fatal("A manifest was not found. Please run `reliably slo init` to create one.")
-			return
+			return errors.New("A manifest was not found. Please run `reliably slo init` to create one.")
 		}
 
-		log.Fatal("An error occured while attempting to load the manifest")
+		return errors.New("An error occured while attempting to load the manifest")
 	}
 
 	reports, err := report.FromManifest(m)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// if err := sendReportToReliably(r); err != nil {
@@ -87,18 +85,20 @@ func run(_ *cobra.Command, _ []string) {
 	if outputPath != "" {
 		if !strings.HasSuffix(outputPath, ".json") {
 			log.Warn("output file should have a .json extension")
-			return
+			return nil
 		}
 
 		bytes, err := json.Marshal(reports)
 		if err != nil {
-			log.Fatal(err)
+			return nil
 		}
 
 		if err := ioutil.WriteFile(outputPath, bytes, 0666); err != nil {
-			log.Fatal(err)
+			return err
 		}
 	}
+
+	return nil
 }
 
 func sendReportToReliably(r *report.Report) error {
@@ -107,11 +107,17 @@ func sendReportToReliably(r *report.Report) error {
 
 // watch - continously fetch and update report
 // and output to terminal
-func watch(manifestPath string) {
+func watch(manifestPath string) error {
 	rChan := make(chan []*report.Report, 5)
-	c := make(chan os.Signal)
+	errChan := make(chan error, 1)
 	done := make(chan struct{})
+	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	defer func() {
+		// put cursor back on return
+		fmt.Print("\033[?25h")
+	}()
 
 	// refresh every 3 seconds
 	go func() {
@@ -119,20 +125,17 @@ func watch(manifestPath string) {
 			m, err := manifest.Load(manifestPath)
 			if err != nil {
 				log.Debug(err)
-
 				if os.IsNotExist(err) {
-					log.Fatal("A manifest was not found. Please run `reliably slo init` to create one.")
+					errChan <- errors.New("A manifest was not found. Please run `reliably slo init` to create one.")
 					return
 				}
-
-				log.Fatal("An error occured while attempting to load the manifest")
+				errChan <- errors.New("An error occured while attempting to load the manifest")
 			}
 
 			reports, err := report.FromManifest(m)
 			if err != nil {
-				log.Fatal(err)
+				errChan <- err
 			}
-
 			rChan <- reports
 		}
 	}()
@@ -140,15 +143,12 @@ func watch(manifestPath string) {
 	// Ctrl+C listener
 	go func() {
 		<-c
-		log.Info("CTRL+C pressed... exiting")
-		// put cursor back on exit
-		fmt.Print("\033[?25h")
+		fmt.Printf("\nCTRL+C pressed... exiting\n")
 		done <- struct{}{}
 	}()
 
 	// print stuff
 	for {
-
 		select {
 		case reports := <-rChan:
 			clearScreen()
@@ -157,8 +157,11 @@ func watch(manifestPath string) {
 				report.Write(report.TABBED, r, os.Stdout, log.StandardLogger())
 			}
 
+		case err := <-errChan:
+			return err
+
 		case <-done:
-			return
+			return nil
 		}
 	}
 

--- a/cmd/reliably/slo/report/cmd.go
+++ b/cmd/reliably/slo/report/cmd.go
@@ -141,7 +141,8 @@ func watch(manifestPath string) {
 	go func() {
 		<-c
 		log.Info("CTRL+C pressed... exiting")
-		// TODO: add any other cleanup actions here if needed
+		// put cursor back on exit
+		fmt.Print("\033[?25h")
 		done <- struct{}{}
 	}()
 
@@ -155,7 +156,11 @@ func watch(manifestPath string) {
 			for _, r := range reports {
 				report.Write(report.TABBED, r, os.Stdout, log.StandardLogger())
 			}
-			// tm.Flush()
+
+			// hide cursor
+			if runtime.GOOS != "" {
+				fmt.Print("\033[?25l")
+			}
 		case <-done:
 			return
 		}
@@ -172,6 +177,9 @@ func clearScreen() {
 	default:
 		// clear should work for UNIX & linux based systems
 		c = exec.Command("clear")
+
+		// hide cursor on unix based systems
+		fmt.Print("\033[?25l")
 	}
 
 	c.Stdout = os.Stdout

--- a/cmd/reliably/slo/report/cmd.go
+++ b/cmd/reliably/slo/report/cmd.go
@@ -3,10 +3,17 @@ package report
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
 	"strings"
+	"syscall"
+	"time"
 
+	"github.com/reliablyhq/cli/core/color"
 	"github.com/reliablyhq/cli/core/manifest"
 	"github.com/reliablyhq/cli/core/report"
 	log "github.com/sirupsen/logrus"
@@ -17,6 +24,7 @@ var (
 	manifestPath string
 	outputPath   string
 	outputFormat string
+	watchFlag    bool
 )
 
 func NewCommand() *cobra.Command {
@@ -29,11 +37,19 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&manifestPath, "manifest", "m", manifest.DefaultManifestPath, "the location of the manifest file")
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "where the report should be written to")
 	cmd.Flags().StringVarP(&outputFormat, "format", "f", "tabbed", "specify the report format. Allowed Values: [json, simple, tabbed]")
+	cmd.Flags().BoolVarP(&watchFlag, "watch", "w", false, "continously watch for changes in report output")
 
 	return cmd
 }
 
 func run(_ *cobra.Command, _ []string) {
+
+	// check for -w/--watch
+	if watchFlag {
+		watch(manifestPath)
+		return
+	}
+
 	m, err := manifest.Load(manifestPath)
 	if err != nil {
 		log.Debug(err)
@@ -87,4 +103,77 @@ func run(_ *cobra.Command, _ []string) {
 
 func sendReportToReliably(r *report.Report) error {
 	return errors.New("Sending reports to Reliably is not available yet. Check back later :D")
+}
+
+// watch - continously fetch and update report
+// and output to terminal
+func watch(manifestPath string) {
+	rChan := make(chan []*report.Report, 5)
+	c := make(chan os.Signal)
+	done := make(chan struct{})
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	// refresh every 3 seconds
+	go func() {
+		for ch := time.Tick(time.Second * 3); ; <-ch {
+			m, err := manifest.Load(manifestPath)
+			if err != nil {
+				log.Debug(err)
+
+				if os.IsNotExist(err) {
+					log.Fatal("A manifest was not found. Please run `reliably slo init` to create one.")
+					return
+				}
+
+				log.Fatal("An error occured while attempting to load the manifest")
+			}
+
+			reports, err := report.FromManifest(m)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			rChan <- reports
+		}
+	}()
+
+	// Ctrl+C listener
+	go func() {
+		<-c
+		log.Info("CTRL+C pressed... exiting")
+		// TODO: add any other cleanup actions here if needed
+		done <- struct{}{}
+	}()
+
+	// print stuff
+	for {
+
+		select {
+		case reports := <-rChan:
+			clearScreen()
+			fmt.Println(color.Magenta("Watching SLO report (3s)"))
+			for _, r := range reports {
+				report.Write(report.TABBED, r, os.Stdout, log.StandardLogger())
+			}
+			// tm.Flush()
+		case <-done:
+			return
+		}
+	}
+
+}
+
+func clearScreen() {
+	var c *exec.Cmd
+
+	switch runtime.GOOS {
+	case "windows":
+		c = exec.Command("cmd", "/c", "cls")
+	default:
+		// clear should work for UNIX & linux based systems
+		c = exec.Command("clear")
+	}
+
+	c.Stdout = os.Stdout
+	c.Run()
 }


### PR DESCRIPTION
This Pull Request adds functionality to the `reliably slo report` command to allow users to watch report updates as they make or the infrastructure changes.

The `-w/--watch` flag operates at the manifest file level, so changes to the file as well as the service metrics  will output to the terminal in real-_ish_ time.

```
$ reliably slo report --watch
```
![image](https://user-images.githubusercontent.com/4018554/114698720-5624e800-9d17-11eb-9a24-57516361eb76.png)

```
Report my slo metrics

Usage:
  reliably slo report [flags]

Flags:
  -f, --format string     specify the report format. Allowed Values: [json, simple, tabbed] (default "tabbed")
  -h, --help              help for report
  -m, --manifest string   the location of the manifest file (default "reliably.yaml")
  -o, --output string     where the report should be written to
  -w, --watch             continously watch for changes in report output <-----

Global Flags:
      --no-color   Disable color output
  -v, --verbose    verbose output

Environment variables:
  See 'reliably environment --help' for the list of supported environment variables.

Feedback:
  You can provide with feedback or report an issue at https://github.com/reliablyhq/cli/issues/new
```

---

- added support for watch flag, -w/--watch
- added cursor hiding mechanism

resolves #160 