### PR TITLE
Add check for blank editors to SLO edit command

### DIFF
--- a/cmd/reliably/help_topic.go
+++ b/cmd/reliably/help_topic.go
@@ -29,8 +29,6 @@ var HelpTopics = map[string]map[string]string{
 			output.
 
 			{{bold "DEBUG:"}} set to any value to enable verbose output.
-
-			{{bold "EDITOR:"}} set default text editor to be used by reliably cli
 		`),
 	},
 }

--- a/cmd/reliably/help_topic.go
+++ b/cmd/reliably/help_topic.go
@@ -29,6 +29,8 @@ var HelpTopics = map[string]map[string]string{
 			output.
 
 			{{bold "DEBUG:"}} set to any value to enable verbose output.
+
+			{{bold "EDITOR:"}} set default text editor to be used by reliably cli
 		`),
 	},
 }

--- a/cmd/reliably/slo/edit/cmd.go
+++ b/cmd/reliably/slo/edit/cmd.go
@@ -24,7 +24,9 @@ func longCommandDescription() string {
 	and opens the default text editor. Once the file is saved and the
 	editor is closed. The resulting file is applied to the organization
 
-	NOTE: This feature only supports terminal based text editors`)
+	NOTE:
+	- This feature only supports terminal based text editors
+	- The EDITOR environment varible can be used to set a default text editor`)
 }
 
 func NewCommand() *cobra.Command {
@@ -41,6 +43,10 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(_ *cobra.Command, args []string) error {
+	if editor == "" {
+		return fmt.Errorf("no text editor detected. please use -e/--editor to specify text editor binary or set the EDITOR env variable")
+	}
+
 	tmpfilePath := fmt.Sprintf(".manifest-edit-%d.yaml", time.Now().Unix())
 	defer os.Remove(tmpfilePath)
 	client := api.NewClientFromHTTP(api.AuthHTTPClient(core.Hostname()))

--- a/cmd/reliably/slo/pull/cmd.go
+++ b/cmd/reliably/slo/pull/cmd.go
@@ -1,11 +1,13 @@
 package pull
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/reliablyhq/cli/api"
 	"github.com/reliablyhq/cli/core"
+	"github.com/reliablyhq/cli/core/cli/question"
 	"github.com/reliablyhq/cli/core/manifest"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -13,8 +15,9 @@ import (
 )
 
 var (
-	output  string
-	service string
+	output       string
+	service      string
+	emptyOptions []question.AskOpt
 )
 
 func NewCommand() *cobra.Command {
@@ -32,6 +35,12 @@ func NewCommand() *cobra.Command {
 }
 
 func runE(_ *cobra.Command, args []string) (err error) {
+	if _, err := os.Stat(output); err == nil {
+		if !question.WithBoolAnswer(fmt.Sprintf("Existing local manifest detected in output path (%s); Do you want to overwrite it?", output), emptyOptions, question.WithNoAsDefault) {
+			return nil
+		}
+	}
+
 	log.Debugf("pulling manifest to: [%s]", output)
 	var m *manifest.Manifest
 	client := api.NewClientFromHTTP(api.AuthHTTPClient(core.Hostname()))


### PR DESCRIPTION
This PR adds a check for a blank editor value when calling the `reliably slo edit` command

```sh
$ EDITOR='' reliably slo edit
Error: no text editor detected. please use -e/--editor to specify text editor binary or set the EDITOR env variable 
```

- Adds overwrite check for existing files on `reliably slo pull` command

```sh
 $ reliably slo pull                                                              
? Existing local manifest detected in output path (reliably.yaml); Do you want to overwrite it? (y/N) 
```
