### PR TITLE
Check SLO service names at form level in init

### DIFF
--- a/cmd/reliably/slo/init/cmd.go
+++ b/cmd/reliably/slo/init/cmd.go
@@ -105,8 +105,6 @@ func runE(_ *cobra.Command, args []string) error {
 func populateManifestInteractively(m *manifest.Manifest) {
 
 	var s manifest.Service
-	s.Name = question.WithStringAnswer("What is the name of the service you want to declare SLOs for?", emptyOptions)
-
 	serviceNameValidator := survey.WithValidator(func(v interface{}) error {
 		for _, s := range m.Services {
 			if s.Name == v.(string) {

--- a/cmd/reliably/slo/init/cmd.go
+++ b/cmd/reliably/slo/init/cmd.go
@@ -105,9 +105,12 @@ func runE(_ *cobra.Command, args []string) error {
 func populateManifestInteractively(m *manifest.Manifest) {
 
 	var s manifest.Service
-
 	s.Name = question.WithStringAnswer("What is the name of the service you want to declare SLOs for?", emptyOptions)
-
+	for checkServiceExists(s.Name, m) {
+		s.Name = question.WithStringAnswer(
+			fmt.Sprintf("Service definition for [%s] already exists, please enter another name:",
+				color.Red(s.Name)), emptyOptions)
+	}
 	declareSLOForService(&s)
 
 	m.Services = append(m.Services, &s)
@@ -277,4 +280,13 @@ func checkPromptExit(err error) {
 	if err == terminal.InterruptErr {
 		os.Exit(0)
 	}
+}
+
+func checkServiceExists(name string, m *manifest.Manifest) bool {
+	for _, s := range m.Services {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/reliably/slo/init/cmd.go
+++ b/cmd/reliably/slo/init/cmd.go
@@ -106,11 +106,20 @@ func populateManifestInteractively(m *manifest.Manifest) {
 
 	var s manifest.Service
 	s.Name = question.WithStringAnswer("What is the name of the service you want to declare SLOs for?", emptyOptions)
-	for checkServiceExists(s.Name, m) {
-		s.Name = question.WithStringAnswer(
-			fmt.Sprintf("Service definition for [%s] already exists, please enter another name:",
-				color.Red(s.Name)), emptyOptions)
-	}
+
+	serviceNameValidator := survey.WithValidator(func(v interface{}) error {
+		for _, s := range m.Services {
+			if s.Name == v.(string) {
+				return fmt.Errorf("service mame [%v] already exists", v)
+			}
+		}
+		return nil
+	})
+
+	s.Name = question.WithStringAnswerV2(
+		"What is the name of the service you want to declare SLOs for?", "",
+		s.Name, []survey.AskOpt{serviceNameValidator})
+
 	declareSLOForService(&s)
 
 	m.Services = append(m.Services, &s)
@@ -280,13 +289,4 @@ func checkPromptExit(err error) {
 	if err == terminal.InterruptErr {
 		os.Exit(0)
 	}
-}
-
-func checkServiceExists(name string, m *manifest.Manifest) bool {
-	for _, s := range m.Services {
-		if s.Name == name {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Resolves #274

This pull requests adds a check at the `reliably slo init` form level to validate against service name duplication.

<img width="681" alt="Screenshot 2021-05-12 at 14 26 16" src="https://user-images.githubusercontent.com/4018554/117982881-59b78900-b32e-11eb-9af0-19652af7f9ec.png">
