### PR TITLE
new apiVersion standard

### DIFF
--- a/api/entities.go
+++ b/api/entities.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/reliablyhq/cli/core/entities"
+	"github.com/reliablyhq/cli/utils"
 )
 
 func CreateEntity(client *Client, hostname string, org string, entity entities.Entity) error {
@@ -20,7 +21,12 @@ func CreateEntity(client *Client, hostname string, org string, entity entities.E
 	kind = plural(entity.Kind())
 	kind = strings.ToLower(kind)
 
-	path := fmt.Sprintf("%s/%s/%s/%s", "entities", version, org, kind)
+	shortVersion, ok := utils.GetShortVersion(version)
+	if !ok {
+		return fmt.Errorf("version %v not supported", version)
+	}
+
+	path := requestPath(shortVersion, kind, org)
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(entity); err != nil {
@@ -33,7 +39,13 @@ func CreateEntity(client *Client, hostname string, org string, entity entities.E
 func GetObjectiveResults(client *Client, hostname string, version string, org string) (*[]entities.ObjectiveResultResponse, error) {
 
 	var entitiesResult *[]entities.ObjectiveResultResponse
-	path := requestPath(version, "objective-results", org)
+
+	shortVersion, ok := utils.GetShortVersion(version)
+	if !ok {
+		return nil, fmt.Errorf("version %v not supported", version)
+	}
+
+	path := requestPath(shortVersion, "objective-results", org)
 	err := client.RESTv2(hostname, http.MethodGet, path, nil, &entitiesResult)
 
 	if err != nil {

--- a/cmd/reliably/alpha/slo/report/cmd.go
+++ b/cmd/reliably/alpha/slo/report/cmd.go
@@ -65,7 +65,6 @@ func AlpaReportRun(opts *sloReport.ReportOptions) error {
 func getReports(manifestPath string) ([]*report.Report, error) {
 
 	reportsLimit := 5
-	apiVersion := "v1"
 
 	var objectives entities.Manifest
 	err := objectives.LoadFromFile(manifestPath)
@@ -76,6 +75,7 @@ func getReports(manifestPath string) ([]*report.Report, error) {
 		return nil, fmt.Errorf("no objectives found")
 	}
 
+	apiVersion := objectives[0].APIVersion
 	hostname := config.Hostname
 	entityHost := config.EntityServerHost
 

--- a/core/entities/objective.go
+++ b/core/entities/objective.go
@@ -30,7 +30,7 @@ func (o *Objective) Kind() string {
 // non-zero values for internal maps
 func NewObjective() *Objective {
 	return &Objective{
-		TypeMeta: TypeMeta{APIVersion: "api.reliably.com/v1", Kind: "Objective"},
+		TypeMeta: TypeMeta{APIVersion: "reliably.com/v1", Kind: "Objective"},
 		Metadata: Metadata{
 			Labels:    Labels{},
 			RelatedTo: []map[string]string{},

--- a/core/entities/objective.go
+++ b/core/entities/objective.go
@@ -30,7 +30,7 @@ func (o *Objective) Kind() string {
 // non-zero values for internal maps
 func NewObjective() *Objective {
 	return &Objective{
-		TypeMeta: TypeMeta{APIVersion: "v1", Kind: "Objective"},
+		TypeMeta: TypeMeta{APIVersion: "api.reliably.com/v1", Kind: "Objective"},
 		Metadata: Metadata{
 			Labels:    Labels{},
 			RelatedTo: []map[string]string{},

--- a/utils/versions.go
+++ b/utils/versions.go
@@ -1,0 +1,16 @@
+package utils
+
+import "strings"
+
+func GetShortVersion(version string) (string, bool) {
+	supportedVersions := []string{
+		"v1",
+	}
+	shortVersion := strings.Split(version, "/")
+	for _, v := range supportedVersions {
+		if v == shortVersion[len(shortVersion)-1] {
+			return v, true
+		}
+	}
+	return "", false
+}

--- a/utils/versions_test.go
+++ b/utils/versions_test.go
@@ -16,7 +16,7 @@ func TestGetShortVersion(t *testing.T) {
 	}{
 		{
 			name: "working standard api version",
-			arg:  "api.reliably.com/v1",
+			arg:  "reliably.com/v1",
 			want: want{
 				shortVersion: "v1",
 				ok:           true,
@@ -32,7 +32,7 @@ func TestGetShortVersion(t *testing.T) {
 		},
 		{
 			name: "unsupported version",
-			arg:  "api.reliably.com/v1000",
+			arg:  "reliably.com/v1000",
 			want: want{
 				shortVersion: "",
 				ok:           false,

--- a/utils/versions_test.go
+++ b/utils/versions_test.go
@@ -54,6 +54,14 @@ func TestGetShortVersion(t *testing.T) {
 				ok:           false,
 			},
 		},
+		{
+			name: "already short version",
+			arg:  "v1",
+			want: want{
+				shortVersion: "v1",
+				ok:           true,
+			},
+		},
 	}
 	_ = tests
 	for _, tt := range tests {

--- a/utils/versions_test.go
+++ b/utils/versions_test.go
@@ -1,0 +1,71 @@
+package utils
+
+import "testing"
+
+func TestGetShortVersion(t *testing.T) {
+
+	type want struct {
+		shortVersion string
+		ok           bool
+	}
+
+	tests := []struct {
+		name string
+		arg  string
+		want
+	}{
+		{
+			name: "working standard api version",
+			arg:  "api.reliably.com/v1",
+			want: want{
+				shortVersion: "v1",
+				ok:           true,
+			},
+		},
+		{
+			name: "many slashes",
+			arg:  "test/tests/v1",
+			want: want{
+				shortVersion: "v1",
+				ok:           true,
+			},
+		},
+		{
+			name: "unsupported version",
+			arg:  "api.reliably.com/v1000",
+			want: want{
+				shortVersion: "",
+				ok:           false,
+			},
+		},
+		{
+			name: "double forward slash",
+			arg:  "test//",
+			want: want{
+				shortVersion: "",
+				ok:           false,
+			},
+		},
+		{
+			name: "empty string",
+			arg:  "",
+			want: want{
+				shortVersion: "",
+				ok:           false,
+			},
+		},
+	}
+	_ = tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotShortVersion, gotOk := GetShortVersion(tt.arg)
+			got := want{
+				shortVersion: gotShortVersion,
+				ok:           gotOk,
+			}
+			if got != tt.want {
+				t.Errorf("got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Changing `apiVersion: v1` to `apiVersion: api.reliably.com/v1`. Also validates if version is supported.