### PR TITLE
Fix trigger release workflow - release branch is not auto deleted once the PR is merged

### DIFF
--- a/.github/workflows/trigger-new-release.yaml
+++ b/.github/workflows/trigger-new-release.yaml
@@ -67,6 +67,7 @@ jobs:
       - name: Delete release branch
         run: |
           git push origin --delete release/${{ github.event.inputs.version }}
+        continue-on-error: true # release branch might be deleted upon PR merge
       - name: Create the git tag (trigger release build)
         run: |
           git checkout main


### PR DESCRIPTION
Signed-off-by: David Martin <david@chaosiq.io>
