### PR TITLE
Release version v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,19 @@
 
 ## [Unreleased]
 
+## [v0.18.0] - 2021-06-17
 
 ### Added
 
-- `slo sync` command allows to synchronize the local objectives with Reliably servers
-- `slo agent` command runs as a background process to periodically fetch your SLIs and send them back to Reliably.
+-   `slo sync` command allows to synchronize the local objectives with Reliably servers
+-   `slo agent` command runs as a background process to periodically fetch your SLIs and send them back to Reliably.
 
 ### Changed
-- Added the formats 'table' & 'text' to the kubernetes scan command. Put 'simple' amd 'tabbed' formats in the deprecated list  ; [#332](https://github.com/reliablyhq/cli/issues/332)
-- Fixed the trend ouput for terminal and included html span elements for markdown type reports  ; [#330](https://github.com/reliablyhq/cli/issues/330)
-- `slo init` and `slo report` have been updated with breaking changes to handle new manifest & objective structure.
-- The SLO manifest has been entirely refactored changed to match the Kubernete-like definition.
+
+-   Added the formats 'table' & 'text' to the kubernetes scan command. Put 'simple' amd 'tabbed' formats in the deprecated list  ; [#332](https://github.com/reliablyhq/cli/issues/332)
+-   Fixed the trend ouput for terminal and included html span elements for markdown type reports  ; [#330](https://github.com/reliablyhq/cli/issues/330)
+-   `slo init` and `slo report` have been updated with breaking changes to handle new manifest & objective structure.
+-   The SLO manifest has been entirely refactored changed to match the Kubernete-like definition.
 
 ## [v0.17.0] - 2021-06-10
 
@@ -244,7 +246,9 @@
 
 -   Initial version
 
-[Unreleased]: https://github.com/reliablyhq/cli/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/reliablyhq/cli/compare/v0.18.0...HEAD
+
+[v0.18.0]: https://github.com/reliablyhq/cli/compare/v0.17.0...v0.18.0
 
 [v0.17.0]: https://github.com/reliablyhq/cli/compare/v0.16.1...v0.17.0
 


### PR DESCRIPTION
This PR was created in response to a manual trigger by @dmartin35 of the release workflow here: https://github.com/reliablyhq/cli/actions/runs/946741561.
I've updated the changelog in this commit: 0d697cbc0c077727b658867db87141a4bcef43cc.
This PR will be automatically merged by @github-actions bot.
Then a new tag on main branch will be pushed to trigger the release of the CLI.