### PR TITLE
Fixes auth login crash with missing config file

### DIFF
--- a/config/file.go
+++ b/config/file.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/fs"
 	"os"
 
 	"github.com/mitchellh/go-homedir"
@@ -39,7 +38,7 @@ func writeConfigFile(data *Config) error {
 	}
 
 	p := resolveConfigFilePath()
-	if err := os.WriteFile(p, bytes, fs.ModeAppend); err != nil {
+	if err := os.WriteFile(p, bytes, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/config/types.go
+++ b/config/types.go
@@ -19,5 +19,7 @@ type (
 
 // NewConfig initializes a config with empty/default values
 func NewConfig() *Config {
-	return &Config{}
+	return &Config{
+		AuthInfo: map[string]AuthInfo{},
+	}
 }


### PR DESCRIPTION
- Init auth map when creating new config - fixes #350
- fix config write perms at creation
