### PR TITLE
Fixes bad config override when using reliably_org env var (org name from config was still used) - fixes #364

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed overidden organization info merged with info from config; [#364](https://github.com/reliablyhq/cli/issues/364)
+
 ## [v0.19.2] - 2021-06-29
 
 ### Fixed

--- a/config/org.go
+++ b/config/org.go
@@ -3,13 +3,15 @@ package config
 import "os"
 
 func GetCurrentOrgInfo() (*OrgInfo, error) {
+	if orgID := os.Getenv(envReliablyOrg); orgID != "" {
+		return &OrgInfo{
+			ID: orgID,
+		}, nil
+	}
+
 	cfg, err := readConfigFile()
 	if err != nil {
 		return nil, err
-	}
-
-	if orgID := os.Getenv(envReliablyOrg); orgID != "" {
-		cfg.CurrentOrg.ID = orgID
 	}
 
 	return &cfg.CurrentOrg, nil


### PR DESCRIPTION
Signed-off-by: David Martin <david@chaosiq.io>
