### PR TITLE
Add delay in the manual release trigger workflow - DCO is lately taking some time to be validated, leaving the PR unmerged

### DIFF
--- a/.github/workflows/trigger-new-release.yaml
+++ b/.github/workflows/trigger-new-release.yaml
@@ -48,6 +48,7 @@ jobs:
             I've updated the changelog in this commit: ${{ steps.make-commit.outputs.commit }}.
             This PR will be automatically merged by @github-actions bot.
             Then a new tag on main branch will be pushed to trigger the release of the CLI.
+      - run: sleep 30 # GH is lately taking some time to validate DCO failing the workflow (leaving the PR unmerged)
       - name: Find pull request
         uses: juliangruber/find-pull-request-action@v1
         id: find-pull-request


### PR DESCRIPTION
Signed-off-by: David Martin <david@chaosiq.io>
