### PR TITLE
added no obj results message

### DIFF
--- a/cmd/reliably/slo/report/cmd.go
+++ b/cmd/reliably/slo/report/cmd.go
@@ -163,7 +163,7 @@ func reportRun(opts *report.ReportOptions) error {
 	if err != nil {
 		return fmt.Errorf("reports error: %w", err)
 	}
-	// TODO: reports wont be empty, need to check empty objective/obj res inside it
+
 	if len(reports[0].Services) == 0 {
 		fmt.Fprintln(opts.IO.ErrOut, color.Yellow("No relevant objective results were found. To generate them, follow these steps:"))
 		fmt.Fprintln(opts.IO.ErrOut, " 1. Define objectives with 'reliably slo init' or manually create them. Find out more: https://reliably.com/docs/guides/slo/define-slos")

--- a/cmd/reliably/slo/report/cmd.go
+++ b/cmd/reliably/slo/report/cmd.go
@@ -163,6 +163,14 @@ func reportRun(opts *report.ReportOptions) error {
 	if err != nil {
 		return fmt.Errorf("reports error: %w", err)
 	}
+	// TODO: reports wont be empty, need to check empty objective/obj res inside it
+	if len(reports[0].Services) == 0 {
+		fmt.Fprintln(opts.IO.ErrOut, color.Yellow("No relevant objective results were found. To generate them, follow these steps:"))
+		fmt.Fprintln(opts.IO.ErrOut, " 1. Define objectives with 'reliably slo init' or manually create them. Find out more: https://reliably.com/docs/guides/slo/define-slos")
+		fmt.Fprintln(opts.IO.ErrOut, " 2. Sync your objectives if you haven't, with 'reliably slo sync'. Find out more: https://reliably.com/docs/reference/cli/reliably-slo-sync")
+		fmt.Fprintln(opts.IO.ErrOut, " 3. Push indicators for these objectives. For this you may use 'reliably slo agent' or manually push them. Find out more: https://reliably.com/docs/guides/slo/sending-custom-indicators")
+		return nil
+	}
 
 	opts.IO.StopProgressIndicator()
 


### PR DESCRIPTION
The instructions may be a little verbose but we don't have them currently on the docs. Once we have a quickstart guide or something that at least has all the steps needed we can shorten the message and link to that.
